### PR TITLE
 [Fix] 적금 상품 목록에 따른 즐겨찾기 여부가 나오도록 변경

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/saving/dto/MySavingProductResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/saving/dto/MySavingProductResponseDTO.java
@@ -27,5 +27,8 @@ public class MySavingProductResponseDTO {
 
     @ApiModelProperty(value = "적금 기간", example = "12")
     private String period;
+
+    @ApiModelProperty(value = "유저 id", example = "1")
+    private Long user_id;
 }
 

--- a/src/main/java/team2/pjt12/matchumoney/domain/saving/dto/SavingListItemResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/saving/dto/SavingListItemResponseDTO.java
@@ -27,5 +27,6 @@ public class SavingListItemResponseDTO {
     String amount;
     @ApiModelProperty(value = "회사 로고 이미지 url", example = "/src/assets/bank-Logos/BK_KB_Profile.png")
     String company_image;
-//    Boolean is_starred;
+    @ApiModelProperty(value = "즐겨찾기 여부", example = "false")
+    Boolean is_starred;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/saving/mapper/SavingAccountMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/saving/mapper/SavingAccountMapper.java
@@ -22,9 +22,9 @@ public interface SavingAccountMapper {
 
     MySavingProductResponseDTO getSavingAccount(@Param("id") Long id);
 
-    List<SavingListItemResponseDTO> getRecommendSavingAccountList(@Param("period") String period, @Param("rate") Double rate);
+    List<SavingListItemResponseDTO> getRecommendSavingAccountList(@Param("period") String period, @Param("rate") Double rate, @Param("user_id") Long userId);
 
-    List<SavingListItemResponseDTO> getRecommendDefaultSavingAccountList();
+    List<SavingListItemResponseDTO> getRecommendDefaultSavingAccountList(@Param("user_id") Long userId);
 
     List<MySavingProductResponseDTO> getSavingAccountList(@Param("userId") Long userId);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/saving/service/SavingAccountServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/saving/service/SavingAccountServiceImpl.java
@@ -142,19 +142,22 @@ public class SavingAccountServiceImpl implements SavingAccountService {
     //내 계좌에 대한 추천 리스트
     @Override
     public List<SavingListItemResponseDTO> getUserRecommendedSavingAccounts(Long id) {
+        Long userId = getCurrentUser().getUserId();
         if (id == -1) {
             return savingAccountMapper.getRecommendDefaultSavingAccountList(userId);
         }
         MySavingProductResponseDTO mySavingProduct = savingAccountMapper.getSavingAccount(id);
         if (mySavingProduct == null) {
 //            log.warn("해당 ID로 조회된 적금 계좌가 없습니다. id={}", id);
-            throw new CustomException(ErrorCode.CODEF_ERROR);
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        if (mySavingProduct.getUser_id() != userId) {
+            throw new CustomException(ErrorCode.USER_NOT_AUTHORIZED);
         }
 //        log.info(String.valueOf(mySavingProduct));
         String period = mySavingProduct.getPeriod();
         double rate = Double.parseDouble(mySavingProduct.getRate());
 
-
-        return savingAccountMapper.getRecommendSavingAccountList(period, rate);
+        return savingAccountMapper.getRecommendSavingAccountList(period, rate, userId);
     }
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/saving/service/SavingAccountServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/saving/service/SavingAccountServiceImpl.java
@@ -143,7 +143,7 @@ public class SavingAccountServiceImpl implements SavingAccountService {
     @Override
     public List<SavingListItemResponseDTO> getUserRecommendedSavingAccounts(Long id) {
         if (id == -1) {
-            return savingAccountMapper.getRecommendDefaultSavingAccountList();
+            return savingAccountMapper.getRecommendDefaultSavingAccountList(userId);
         }
         MySavingProductResponseDTO mySavingProduct = savingAccountMapper.getSavingAccount(id);
         if (mySavingProduct == null) {

--- a/src/main/resources/mapper/SavingAccountMapper.xml
+++ b/src/main/resources/mapper/SavingAccountMapper.xml
@@ -25,7 +25,8 @@
                res_account_start_date AS start_date,
                res_account_end_date   AS end_date,
                res_rate               AS rate,
-               res_valid_period       AS period
+               res_valid_period       AS period,
+               user_id                as user_id
         FROM mydata_saving_accounts
         WHERE user_id = #{userId}
     </select>
@@ -38,7 +39,8 @@
                res_account_start_date AS start_date,
                res_account_end_date   AS end_date,
                res_rate               AS rate,
-               res_valid_period       AS period
+               res_valid_period       AS period,
+               user_id                as user_id
         FROM mydata_saving_accounts
         WHERE account_id = #{id}
     </select>

--- a/src/main/resources/mapper/SavingAccountMapper.xml
+++ b/src/main/resources/mapper/SavingAccountMapper.xml
@@ -53,19 +53,24 @@
                so.intr_rate2        AS max_rate,
                so.save_trm          AS period,
                sp.max_limit         AS amount,
-               fc.company_image     as company_image
+               fc.company_image     AS company_image,
+               CASE
+                   WHEN uf.favorite_id IS NOT NULL THEN TRUE
+                   ELSE FALSE
+                   END              AS is_starred
         FROM saving_product sp
                  JOIN saving_option so
                       ON sp.fin_prdt_cd = so.fin_prdt_cd
                           AND sp.fin_id = so.fin_id
                  LEFT OUTER JOIN financial_companies fc
-                                 ON sp.kor_co_nm = fc.kor_co_nm
+                                 ON INSTR(sp.kor_co_nm, fc.kor_co_nm) > 0
+                                     OR INSTR(fc.kor_co_nm, sp.kor_co_nm) > 0
+                 LEFT OUTER JOIN user_favorites uf
+                                 ON uf.saving_product_id = sp.saving_product_id
+                                     AND uf.user_id = #{user_id}
         WHERE so.save_trm = #{period}
-          AND CAST(so.intr_rate AS DECIMAL(5
-            , 4))
-            > #{rate}
-        ORDER BY CAST(so.intr_rate AS DECIMAL(5, 4))
-            DESC
+          AND CAST(so.intr_rate AS DECIMAL(5, 4)) > #{rate}
+        ORDER BY CAST(so.intr_rate AS DECIMAL(5, 4)) DESC
     </select>
 
     <select id="getRecommendDefaultSavingAccountList"
@@ -77,28 +82,19 @@
                so.intr_rate2        as max_rate,
                so.save_trm          as period,
                sp.max_limit         as amount,
-               fc.company_image     as company_image
+               fc.company_image     as company_image,
+               CASE
+                   WHEN uf.favorite_id IS NOT NULL THEN TRUE
+                   ELSE FALSE
+                   END              AS is_starred
         FROM saving_product sp
                  JOIN
              saving_option so ON sp.fin_prdt_cd = so.fin_prdt_cd AND sp.fin_id = so.fin_id
                  LEFT OUTER JOIN financial_companies fc
                                  ON sp.kor_co_nm = fc.kor_co_nm
-        WHERE so.save_trm = 12
-          AND so.fin_id = 11
-        ORDER BY CAST(so.intr_rate AS DECIMAL(5, 4)) DESC
-    </select>
-    <select id="getRecommendDefaultSavingAccountList"
-            resultType="team2.pjt12.matchumoney.domain.saving.dto.SavingListItemResponseDTO">
-        SELECT sp.saving_product_id as id,
-               sp.kor_co_nm         as company,
-               sp.fin_prdt_nm       AS title,
-               so.intr_rate         as base_rate,
-               so.intr_rate2        as max_rate,
-               so.save_trm          as period,
-               sp.max_limit         as amount
-        FROM saving_product sp
-                 JOIN
-             saving_option so ON sp.fin_prdt_cd = so.fin_prdt_cd AND sp.fin_id = so.fin_id
+                 LEFT OUTER JOIN user_favorites uf
+                                 ON uf.saving_product_id = sp.saving_product_id
+                                     AND uf.user_id = #{user_id}
         WHERE so.save_trm = 12
           AND so.fin_id = 11
         ORDER BY CAST(so.intr_rate AS DECIMAL(5, 4)) DESC


### PR DESCRIPTION
## 🔥 PR 제목
- [Fix] 적금 상품 목록에 따른 즐겨찾기 여부가 나오도록 변경

---

## 📎 관련 이슈
- Closes #25

---

## 🛠 작업 내용
- 즐겨찾기 여부를 알 수 있도록 적금 추천 목록 조회에 is_starred 추가(true: 즐겨찾기 O, false: 즐겨찾기 X)
<img width="572" height="392" alt="image" src="https://github.com/user-attachments/assets/1d0aaae4-18b1-4fb2-9e07-2efdfaead6f6" />
- 내 보유 적금이 아닌 적금에 추천을 요청할 경우 오류 반환되도록 변경(보안 강화)
<img width="621" height="201" alt="image" src="https://github.com/user-attachments/assets/606afbad-bc23-4c76-b4bd-07688381b5cc" />





