### PR TITLE
[Fix] 카카오 로그인 userid 저장 오류

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/auth/dto/LoginResponseDTO.java
@@ -1,13 +1,14 @@
 package team2.pjt12.matchumoney.domain.auth.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class LoginResponseDTO {
 
     private final String accessToken;
-
-    public LoginResponseDTO(String accessToken) {
-        this.accessToken = accessToken;
-    }
+    private final Long userId;
+    private final String nickname;
+    private final Long personaId;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/auth/service/AuthServiceImpl.java
@@ -50,7 +50,12 @@ public class AuthServiceImpl implements AuthService{
 
         String jwt = jwtService.createAccessToken(user);
 
-        return new LoginResponseDTO(jwt);
+        return LoginResponseDTO.builder()
+                .accessToken(jwt)
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .personaId(user.getPersonaId())
+                .build();
     }
 
     private UserVO registerUser(SocialUserInfo info) {


### PR DESCRIPTION
## 🔥 PR 제목
- [Fix] 카카오-로그인-userid-저장-오류

---

## 📎 관련 이슈
- Closes #62
---

## 🛠 작업 내용
- 프론트에서 카카오 로그인시 userId를 저장을 못하고 있어서 반환 값을 수정 진행
- 정상적으로 프론트에서 session storage로 저장 가능


