### PR TITLE
[Feat] 일일 금융 퀴즈 구현

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/controller/QuizController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/controller/QuizController.java
@@ -1,0 +1,99 @@
+package team2.pjt12.matchumoney.domain.quiz.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.service.QuizService;
+import team2.pjt12.matchumoney.global.security.UserDetailsImpl;
+import team2.pjt12.matchumoney.global.success.SuccessResponse;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz")
+@Slf4j
+@Api(tags = "퀴즈", description = "금융 퀴즈 문제 조회/제출/통계 API")
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @GetMapping("/today")
+    @ApiOperation(
+            value = "오늘의 퀴즈 문제 조회",
+            notes = "사용자별로 오늘 풀어야 할 금융 퀴즈 문제를 1개 제공합니다. 이미 오늘 문제를 모두 푼 경우 400 오류가 발생할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "퀴즈 문제 조회 성공"),
+            @ApiResponse(code = 401, message = "인증 실패"),
+            @ApiResponse(code = 400, message = "오늘 풀 수 있는 문제가 없음")
+    })
+    public SuccessResponse<QuizProblemResponseDTO> getTodayQuiz(
+            @ApiParam(hidden = true) Authentication authentication) {
+        Long userId = getUserId(authentication);
+        QuizProblemResponseDTO response = quizService.getTodayQuiz(userId);
+        return new SuccessResponse<>(response);
+    }
+
+    @PostMapping("/submit")
+    @ApiOperation(
+            value = "퀴즈 정답 제출",
+            notes = "사용자가 오늘의 퀴즈 문제에 대한 답을 제출합니다. 정답일 경우 경험치 10점을 획득합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "퀴즈 정답 제출 결과"),
+            @ApiResponse(code = 400, message = "요청 데이터 오류 또는 이미 제출한 문제"),
+            @ApiResponse(code = 401, message = "인증 실패")
+    })
+    public SuccessResponse<QuizResultResponseDTO> submitAnswer(
+            @ApiParam(hidden = true) Authentication authentication,
+            @ApiParam(value = "정답 제출 요청 DTO", required = true)
+            @RequestBody @Valid QuizAnswerRequestDTO requestDTO) {
+        Long userId = getUserId(authentication);
+        QuizResultResponseDTO response = quizService.submitAnswer(userId, requestDTO);
+        return new SuccessResponse<>(response);
+    }
+
+    @GetMapping("/stats")
+    @ApiOperation(
+            value = "사용자 퀴즈 통계 조회",
+            notes = "사용자가 지금까지 푼 금융 퀴즈의 정답/오답 수, 연속 정답(스트릭), 누적 경험치 등을 제공합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "퀴즈 통계 조회 성공"),
+            @ApiResponse(code = 401, message = "인증 실패")
+    })
+    public SuccessResponse<QuizStatsResponseDTO> getUserStats(
+            @ApiParam(hidden = true) Authentication authentication) {
+        Long userId = getUserId(authentication);
+        QuizStatsResponseDTO response = quizService.getUserQuizStats(userId);
+        return new SuccessResponse<>(response);
+    }
+
+    @GetMapping("/today/completed")
+    @ApiOperation(
+            value = "오늘의 퀴즈 완료 여부 조회",
+            notes = "오늘 퀴즈를 모두 풀었는지 여부를 반환합니다. true면 완료, false면 아직 미완료입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "오늘의 퀴즈 완료 여부 반환"),
+            @ApiResponse(code = 401, message = "인증 실패")
+    })
+    public SuccessResponse<Boolean> checkTodayQuizCompleted(
+            @ApiParam(hidden = true) Authentication authentication) {
+        Long userId = getUserId(authentication);
+        boolean completed = quizService.hasCompletedTodayQuiz(userId);
+        return new SuccessResponse<>(completed);
+    }
+
+    private Long getUserId(Authentication authentication) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        return userDetails.getUser().getUserId();
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/domain/QuizLogVO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/domain/QuizLogVO.java
@@ -1,0 +1,30 @@
+package team2.pjt12.matchumoney.domain.quiz.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class QuizLogVO {
+
+    private Long logId;
+    private Long userId;
+    private Long problemId;
+    private Boolean userAnswer;
+    private Boolean isCorrect;
+    private LocalDateTime solvedTime;
+    private LocalDate solvedDate;
+
+    @Builder
+    public QuizLogVO(Long userId, Long problemId, Boolean userAnswer, Boolean isCorrect, LocalDate solvedDate) {
+        this.userId = userId;
+        this.problemId = problemId;
+        this.userAnswer = userAnswer;
+        this.isCorrect = isCorrect;
+        this.solvedDate = solvedDate;
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/domain/QuizProblemVO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/domain/QuizProblemVO.java
@@ -1,0 +1,27 @@
+package team2.pjt12.matchumoney.domain.quiz.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class QuizProblemVO {
+
+    private Long problemId;
+    private String quizText;
+    private Boolean quizAnswer;
+    private String explanation;
+    private LocalDateTime createdTime;
+    private LocalDateTime lastModifiedTime;
+
+    @Builder
+    public QuizProblemVO(Long problemId, String quizText, Boolean quizAnswer, String explanation) {
+        this.problemId = problemId;
+        this.quizText = quizText;
+        this.quizAnswer = quizAnswer;
+        this.explanation = explanation;
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/req/QuizAnswerRequestDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/req/QuizAnswerRequestDTO.java
@@ -1,0 +1,12 @@
+package team2.pjt12.matchumoney.domain.quiz.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAnswerRequestDTO {
+
+    private Long problemId;
+    private Boolean userAnswer;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizProblemResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizProblemResponseDTO.java
@@ -1,0 +1,22 @@
+package team2.pjt12.matchumoney.domain.quiz.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
+
+@Getter
+@Builder
+public class QuizProblemResponseDTO {
+
+    private Long problemId;
+    private String quizText;
+    private String explanation;
+
+    public static QuizProblemResponseDTO from(QuizProblemVO quizProblem) {
+        return QuizProblemResponseDTO.builder()
+                .problemId(quizProblem.getProblemId())
+                .quizText(quizProblem.getQuizText())
+                .explanation(quizProblem.getExplanation())
+                .build();
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizResultResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizResultResponseDTO.java
@@ -1,0 +1,14 @@
+package team2.pjt12.matchumoney.domain.quiz.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizResultResponseDTO {
+
+    private Boolean isCorrect;
+    private Boolean correctAnswer;
+    private String explanation;
+    private Integer earnedXP;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizStatsResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizStatsResponseDTO.java
@@ -1,0 +1,14 @@
+package team2.pjt12.matchumoney.domain.quiz.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizStatsResponseDTO {
+
+    private Integer correct;
+    private Integer wrong;
+    private Integer streak;
+    private Integer totalXP;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizLogMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizLogMapper.java
@@ -1,0 +1,36 @@
+package team2.pjt12.matchumoney.domain.quiz.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface QuizLogMapper {
+
+    void save(QuizLogVO quizLog);
+    
+    List<QuizLogVO> findByUserId(@Param("userId") Long userId);
+    
+    QuizLogVO findByUserIdAndProblemIdAndDate(
+            @Param("userId") Long userId, 
+            @Param("problemId") Long problemId, 
+            @Param("solvedDate") LocalDate solvedDate
+    );
+    
+    boolean existsByUserIdAndDate(@Param("userId") Long userId, @Param("solvedDate") LocalDate solvedDate);
+    
+    boolean existsByUserIdAndProblemId(@Param("userId") Long userId, @Param("problemId") Long problemId);
+    
+    int getCorrectCountByUserId(@Param("userId") Long userId);
+    
+    int getWrongCountByUserId(@Param("userId") Long userId);
+    
+    int getCurrentStreakByUserId(@Param("userId") Long userId);
+    
+    List<QuizLogVO> findRecentLogsByUserId(@Param("userId") Long userId, @Param("limit") int limit);
+    
+    void deleteById(@Param("logId") Long logId);
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizProblemMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizProblemMapper.java
@@ -1,0 +1,31 @@
+package team2.pjt12.matchumoney.domain.quiz.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
+
+import java.util.List;
+
+@Mapper
+public interface QuizProblemMapper {
+
+    List<QuizProblemVO> findAll();
+    
+    QuizProblemVO findById(@Param("problemId") Long problemId);
+    
+    void save(QuizProblemVO quizProblem);
+    
+    void update(QuizProblemVO quizProblem);
+    
+    void deleteById(@Param("problemId") Long problemId);
+    
+    QuizProblemVO findRandomProblem();
+    
+    List<QuizProblemVO> findUnsolvedProblemsByUserId(@Param("userId") Long userId);
+    
+    QuizProblemVO findRandomUnsolvedProblem(@Param("userId") Long userId);
+    
+    int getTotalCount();
+    
+    int getUnsolvedCountByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizService.java
@@ -1,0 +1,17 @@
+package team2.pjt12.matchumoney.domain.quiz.service;
+
+import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
+
+public interface QuizService {
+
+    QuizProblemResponseDTO getTodayQuiz(Long userId);
+    
+    QuizResultResponseDTO submitAnswer(Long userId, QuizAnswerRequestDTO requestDTO);
+    
+    QuizStatsResponseDTO getUserQuizStats(Long userId);
+    
+    boolean hasCompletedTodayQuiz(Long userId);
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceImpl.java
@@ -1,0 +1,102 @@
+package team2.pjt12.matchumoney.domain.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
+import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.mapper.QuizLogMapper;
+import team2.pjt12.matchumoney.domain.quiz.mapper.QuizProblemMapper;
+import team2.pjt12.matchumoney.domain.user.mapper.UserMapper;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizServiceImpl implements QuizService {
+
+    private final QuizProblemMapper quizProblemMapper;
+    private final QuizLogMapper quizLogMapper;
+    private final UserMapper userMapper; // (1) UserMapper 의존성 추가
+
+    @Override
+    public QuizProblemResponseDTO getTodayQuiz(Long userId) {
+        int unsolvedCount = quizProblemMapper.getUnsolvedCountByUserId(userId);
+
+        if (unsolvedCount == 0) {
+            throw new RuntimeException("풀 수 있는 문제가 더 이상 없습니다. 모든 문제를 완료했습니다!");
+        }
+
+        QuizProblemVO randomUnsolvedProblem = quizProblemMapper.findRandomUnsolvedProblem(userId);
+
+        if (randomUnsolvedProblem == null) {
+            throw new RuntimeException("퀴즈 문제를 가져오는데 실패했습니다.");
+        }
+
+        return QuizProblemResponseDTO.from(randomUnsolvedProblem);
+    }
+
+    @Override
+    @Transactional
+    public QuizResultResponseDTO submitAnswer(Long userId, QuizAnswerRequestDTO requestDTO) {
+        QuizProblemVO problem = quizProblemMapper.findById(requestDTO.getProblemId());
+        if (problem == null) {
+            throw new RuntimeException("존재하지 않는 문제입니다.");
+        }
+
+        if (quizLogMapper.existsByUserIdAndProblemId(userId, requestDTO.getProblemId())) {
+            throw new RuntimeException("이미 푼 문제입니다.");
+        }
+
+        boolean isCorrect = problem.getQuizAnswer().equals(requestDTO.getUserAnswer());
+        int earnedXP = isCorrect ? 10 : 0;
+
+        // (2) 정답시 경험치 증가
+        if (isCorrect) {
+            userMapper.updateUserExp(userId, earnedXP);
+        }
+
+        // 퀴즈 풀이 로그 저장
+        QuizLogVO quizLog = QuizLogVO.builder()
+                .userId(userId)
+                .problemId(requestDTO.getProblemId())
+                .userAnswer(requestDTO.getUserAnswer())
+                .isCorrect(isCorrect)
+                .solvedDate(LocalDate.now())
+                .build();
+
+        quizLogMapper.save(quizLog);
+
+        return QuizResultResponseDTO.builder()
+                .isCorrect(isCorrect)
+                .correctAnswer(problem.getQuizAnswer())
+                .explanation(problem.getExplanation())
+                .earnedXP(earnedXP)
+                .build();
+    }
+
+    @Override
+    public QuizStatsResponseDTO getUserQuizStats(Long userId) {
+        int correctCount = quizLogMapper.getCorrectCountByUserId(userId);
+        int wrongCount = quizLogMapper.getWrongCountByUserId(userId);
+        int streak = quizLogMapper.getCurrentStreakByUserId(userId);
+        int totalXP = correctCount * 10;
+
+        return QuizStatsResponseDTO.builder()
+                .correct(correctCount)
+                .wrong(wrongCount)
+                .streak(streak)
+                .totalXP(totalXP)
+                .build();
+    }
+
+    @Override
+    public boolean hasCompletedTodayQuiz(Long userId) {
+        return quizLogMapper.existsByUserIdAndDate(userId, LocalDate.now());
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/user/mapper/UserMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/mapper/UserMapper.java
@@ -76,4 +76,7 @@ public interface UserMapper {
     void updatePersona(@Param("userId") Long userId, @Param("personaId") String personaId);
 
     Optional<PersonaSimpleResponseDTO> getPersonaByUserId(@Param("userId") Long userId);
+    
+    // 경험치(EXP) 업데이트
+    void updateUserExp(@Param("userId") Long userId, @Param("expAmount") int expAmount);
 }

--- a/src/main/resources/mapper/QuizLogMapper.xml
+++ b/src/main/resources/mapper/QuizLogMapper.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="team2.pjt12.matchumoney.domain.quiz.mapper.QuizLogMapper">
+
+    <resultMap id="QuizLogResultMap" type="team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO">
+        <id property="logId" column="log_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="problemId" column="problem_id"/>
+        <result property="userAnswer" column="user_answer"/>
+        <result property="isCorrect" column="is_correct"/>
+        <result property="solvedTime" column="solved_time"/>
+        <result property="solvedDate" column="solved_date"/>
+    </resultMap>
+
+    <insert id="save" parameterType="team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO" useGeneratedKeys="true" keyProperty="logId">
+        INSERT INTO quiz_log (user_id, problem_id, user_answer, is_correct, solved_date)
+        VALUES (#{userId}, #{problemId}, #{userAnswer}, #{isCorrect}, #{solvedDate})
+    </insert>
+
+    <select id="findByUserId" parameterType="Long" resultMap="QuizLogResultMap">
+        SELECT log_id, user_id, problem_id, user_answer, is_correct, solved_time, solved_date
+        FROM quiz_log
+        WHERE user_id = #{userId}
+        ORDER BY solved_time DESC
+    </select>
+
+    <select id="findByUserIdAndProblemIdAndDate" resultMap="QuizLogResultMap">
+        SELECT log_id, user_id, problem_id, user_answer, is_correct, solved_time, solved_date
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND problem_id = #{problemId}
+          AND solved_date = #{solvedDate}
+    </select>
+
+    <select id="existsByUserIdAndDate" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND solved_date = #{solvedDate}
+    </select>
+
+    <select id="existsByUserIdAndProblemId" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND problem_id = #{problemId}
+    </select>
+
+    <select id="getCorrectCountByUserId" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND is_correct = 1
+    </select>
+
+    <select id="getWrongCountByUserId" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND is_correct = 0
+    </select>
+
+    <select id="getCurrentStreakByUserId" parameterType="Long" resultType="int">
+        <![CDATA[
+        SELECT COUNT(*) AS current_streak
+        FROM (
+                 SELECT
+                     is_correct,
+                     SUM(CASE WHEN is_correct = 0 THEN 1 ELSE 0 END)
+                         OVER (ORDER BY solved_date DESC) AS wrongs
+                 FROM quiz_log
+                 WHERE user_id = #{userId}
+                 ORDER BY solved_date DESC
+             ) t
+        WHERE wrongs = 0
+        ]]>
+    </select>
+
+    <select id="findRecentLogsByUserId" resultMap="QuizLogResultMap">
+        SELECT log_id, user_id, problem_id, user_answer, is_correct, solved_time, solved_date
+        FROM quiz_log
+        WHERE user_id = #{userId}
+        ORDER BY solved_time DESC
+        LIMIT #{limit}
+    </select>
+
+    <delete id="deleteById" parameterType="Long">
+        DELETE FROM quiz_log
+        WHERE log_id = #{logId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/QuizProblemMapper.xml
+++ b/src/main/resources/mapper/QuizProblemMapper.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="team2.pjt12.matchumoney.domain.quiz.mapper.QuizProblemMapper">
+    
+    <resultMap id="QuizProblemResultMap" type="team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO">
+        <id property="problemId" column="problem_id"/>
+        <result property="quizText" column="quiz_text"/>
+        <result property="quizAnswer" column="quiz_answer"/>
+        <result property="explanation" column="explanation"/>
+        <result property="createdTime" column="created_time"/>
+        <result property="lastModifiedTime" column="last_modified_time"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="QuizProblemResultMap">
+        SELECT problem_id, quiz_text, quiz_answer, explanation, created_time, last_modified_time
+        FROM quiz_problem
+        ORDER BY problem_id
+    </select>
+
+    <select id="findById" parameterType="Long" resultMap="QuizProblemResultMap">
+        SELECT problem_id, quiz_text, quiz_answer, explanation, created_time, last_modified_time
+        FROM quiz_problem
+        WHERE problem_id = #{problemId}
+    </select>
+
+    <insert id="save" parameterType="team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO" useGeneratedKeys="true" keyProperty="problemId">
+        INSERT INTO quiz_problem (quiz_text, quiz_answer, explanation)
+        VALUES (#{quizText}, #{quizAnswer}, #{explanation})
+    </insert>
+
+    <update id="update" parameterType="team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO">
+        UPDATE quiz_problem
+        SET quiz_text = #{quizText},
+            quiz_answer = #{quizAnswer},
+            explanation = #{explanation},
+            last_modified_time = NOW()
+        WHERE problem_id = #{problemId}
+    </update>
+
+    <delete id="deleteById" parameterType="Long">
+        DELETE FROM quiz_problem
+        WHERE problem_id = #{problemId}
+    </delete>
+
+    <select id="findRandomProblem" resultMap="QuizProblemResultMap">
+        SELECT problem_id, quiz_text, quiz_answer, explanation, created_time, last_modified_time
+        FROM quiz_problem
+        ORDER BY RAND()
+        LIMIT 1
+    </select>
+
+    <select id="findUnsolvedProblemsByUserId" parameterType="Long" resultMap="QuizProblemResultMap">
+        SELECT p.problem_id, p.quiz_text, p.quiz_answer, p.explanation, p.created_time, p.last_modified_time
+        FROM quiz_problem p
+        WHERE p.problem_id NOT IN (
+            SELECT DISTINCT ql.problem_id 
+            FROM quiz_log ql 
+            WHERE ql.user_id = #{userId}
+        )
+        ORDER BY p.problem_id
+    </select>
+
+    <select id="findRandomUnsolvedProblem" parameterType="Long" resultMap="QuizProblemResultMap">
+        SELECT p.problem_id, p.quiz_text, p.quiz_answer, p.explanation, p.created_time, p.last_modified_time
+        FROM quiz_problem p
+        WHERE p.problem_id NOT IN (
+            SELECT DISTINCT ql.problem_id 
+            FROM quiz_log ql 
+            WHERE ql.user_id = #{userId}
+        )
+        ORDER BY RAND()
+        LIMIT 1
+    </select>
+
+    <select id="getTotalCount" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_problem
+    </select>
+
+    <select id="getUnsolvedCountByUserId" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_problem p
+        WHERE p.problem_id NOT IN (
+            SELECT DISTINCT ql.problem_id 
+            FROM quiz_log ql 
+            WHERE ql.user_id = #{userId}
+        )
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -178,14 +178,14 @@
                                   ROW_NUMBER() OVER (
                                       PARTITION BY fin_prdt_cd
                                       ORDER BY CASE WHEN save_trm = 12 THEN 1 ELSE 2 END, save_trm DESC
-                                  ) AS rn
+                                      ) AS rn
                               FROM deposit_option
                           ) tmp
                      WHERE rn = 1
                  ) opt ON dp.fin_prdt_cd = opt.fin_prdt_cd
                  WHERE uf.user_id = #{userId}
                  ORDER BY RAND()
-                     LIMIT 2
+                 LIMIT 2
              ) AS random_deposit
     </select>
 
@@ -211,10 +211,10 @@
                                      ROW_NUMBER() OVER (
                                          PARTITION BY fin_prdt_cd
                                          ORDER BY CASE WHEN save_trm = 12 THEN 1
-                                                      WHEN save_trm = 6 THEN 2
-                                                      WHEN save_trm = 1 THEN 3
-                                                      ELSE 4 END
-                                 ) AS rn
+                                                       WHEN save_trm = 6 THEN 2
+                                                       WHEN save_trm = 1 THEN 3
+                                                       ELSE 4 END
+                                         ) AS rn
                               FROM saving_option
                           ) ranked
                      WHERE rn = 1
@@ -223,7 +223,7 @@
                                     ON sp.kor_co_nm LIKE CONCAT('%', fc.kor_co_nm, '%')
                  WHERE uf.user_id = #{userId}
                  ORDER BY RAND()
-                     LIMIT 2
+                 LIMIT 2
              ) AS random_saving
     </select>
 
@@ -242,7 +242,7 @@
                           JOIN card_product c ON uf.card_product_id = c.card_product_id
                  WHERE uf.user_id = #{userId}
                  ORDER BY RAND()
-                     LIMIT 2
+                 LIMIT 2
              ) AS random_card
     </select>
 
@@ -276,4 +276,11 @@
             SELECT persona_id FROM users WHERE user_id = #{userId}
         )
     </select>
+
+    <!-- 경험치(EXP) 업데이트 -->
+    <update id="updateUserExp">
+        UPDATE users
+        SET exp = exp + #{expAmount}
+        WHERE user_id = #{userId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 일일 금융 퀴즈 구현

---

## 📎 관련 이슈
- Closes #75

---

## 🛠 작업 내용
- 일일 금융 퀴즈 문제 제공
- O/X 형식의 문제 제공
- 퀴즈 정답 시 경험치 제공
- 하루에 한문제 제공
- 문제는 랜덤 출제 이미 풀었던 문제는 제출 안함



