### PR TITLE
[Feat] 카드 필터링 검색 응답에 즐겨찾기 여부 값 포함

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchResponseDTO.java
@@ -19,5 +19,5 @@ public class CardSearchResponseDTO {
     private String annualFee;   // 연회비
     private Integer preMonthMoney; // 전월 실적
     private List<CardOptionDTO> options;
-
+    private Boolean isStarred;
 }

--- a/src/main/resources/mapper/CardSearchMapper.xml
+++ b/src/main/resources/mapper/CardSearchMapper.xml
@@ -15,8 +15,13 @@
         cp.issuer,
         cp.annual_fee AS annualFee,
         cp.pre_month_money AS preMonthMoney,
-        cp.card_image_url AS imageUrl
+        cp.card_image_url AS imageUrl,
+        CASE
+        WHEN uf.favorite_id IS NOT NULL THEN TRUE
+        ELSE FALSE
+        END AS isStarred
         FROM card_product cp
+        LEFT JOIN user_favorites uf ON cp.card_product_id = uf.card_product_id
         <if test="selectedBenefits != null and selectedBenefits.size() > 0">
             LEFT JOIN card_search_benefit csb ON cp.card_product_id = csb.card_id2
         </if>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 카드 필터링 검색 응답에 즐겨찾기 여부 값 포함

---

## 📎 관련 이슈
- Closes #84 

---

## 🛠 작업 내용
- 즐겨찾기 여부 넘겨주기 위한 isStarred 값 추가
