### PR TITLE
[Feat] 적금 필터링 검색 응답에 즐겨찾기 여부 값 포함

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/savingsearch/dto/SavingSearchResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/savingsearch/dto/SavingSearchResponseDTO.java
@@ -13,4 +13,5 @@ public class SavingSearchResponseDTO {
     private String benefit;
     private String personaType;
     private List<SavingOptionDTO> savingOptions;  // ✅ 금리 옵션 리스트 추가
+    private Boolean isStarred;
 }

--- a/src/main/resources/mapper/SavingSearchMapper.xml
+++ b/src/main/resources/mapper/SavingSearchMapper.xml
@@ -13,8 +13,13 @@
         sp.fin_prdt_cd AS finPrdtCd,
         sp.fin_prdt_nm AS finPrdtNm,
         sp.max_limit AS maxLimit,
-        sp.spcl_cnd AS benefit
+        sp.spcl_cnd AS benefit,
+        CASE
+        WHEN uf.favorite_id IS NOT NULL THEN TRUE
+        ELSE FALSE
+        END AS isStarred
         FROM saving_product sp
+        LEFT JOIN user_favorites uf ON sp.saving_product_id = uf.saving_product_id
         WHERE 1 = 1
         <if test="korCoNm != null and korCoNm != ''">
             AND sp.kor_co_nm LIKE CONCAT('%', #{korCoNm}, '%')


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 적금 필터링 검색 응답에 즐겨찾기 여부 값 포함

---

## 📎 관련 이슈
- Closes #86 

---

## 🛠 작업 내용
- 즐겨찾기 여부 넘겨주기 위한 isStarred 값 추가



