### PR TITLE
[Feat] connectedid를 이용하여 보유 카드 리스트 거래내역 한번에 조회

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationServiceImpl.java
@@ -34,18 +34,21 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
 
     @Override
     public MyCardBenefitResponseDTO calculateSpecificCardBenefit(Long userId, Integer cardId) {
-        log.info("사용자 {}의 특정 카드 {} 혜택 계산 시작", userId, cardId);
+        log.info("🔍 사용자 {}의 특정 카드 {} 혜택 계산 시작", userId, cardId);
 
         // 분석 기간 설정 (최근 30일)
         LocalDate endDate = LocalDate.now();
         LocalDate startDate = endDate.minusDays(ANALYSIS_PERIOD_DAYS);
 
-        // 특정 카드의 카테고리별 거래 통계 조회
+        // 특정 카드의 카테고리별 거래 통계 조회 (holding_id 기준)
+        log.info("🔍 거래내역 통계 조회 - userId: {}, cardId: {}, 기간: {} ~ {}", 
+            userId, cardId, startDate, endDate);
         List<CardTransactionSummaryVO> transactionSummaries = 
             cardRecommendationMapper.selectTransactionSummaryByUserAndCard(userId, cardId, startDate, endDate);
 
+        log.info("📊 거래내역 통계 조회 완료 - 카테고리 수: {}", transactionSummaries.size());
         if (transactionSummaries.isEmpty()) {
-            log.warn("사용자 {}의 카드 {}에 대한 최근 {}일 거래 내역이 없습니다.", userId, cardId, ANALYSIS_PERIOD_DAYS);
+            log.warn("⚠️ 사용자 {}의 카드 {}에 대한 최근 {}일 거래 내역이 없습니다.", userId, cardId, ANALYSIS_PERIOD_DAYS);
             return MyCardBenefitResponseDTO.builder()
                 .totalSpendAmount(0L)
                 .categoryStats(Collections.emptyList())
@@ -286,11 +289,18 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
 
         for (CardProductVO card : ownedCards) {
             try {
+                log.info("🔍 카드 혜택 계산 시작 - 카드: '{}', cardProductId: {}", 
+                    card.getName(), card.getCardProductId());
                 MyCardBenefitResponseDTO cardBenefit = calculateSpecificCardBenefit(userId, card.getCardProductId());
                 myCardsBenefits.add(cardBenefit);
+                long totalBenefit = cardBenefit.getOwnedCardBenefits().stream()
+                    .mapToLong(benefit -> benefit.getEstimatedBenefit() != null ? benefit.getEstimatedBenefit() : 0L)
+                    .sum();
+                log.info("✅ 카드 혜택 계산 완료 - 카드: '{}', 총혜택: {}원, 카테고리: {}개", 
+                    card.getName(), totalBenefit, cardBenefit.getCategoryStats().size());
             } catch (Exception e) {
-                log.warn("사용자 {}의 카드 {} 혜택 계산 중 오류 발생, 건너뜁니다: {}", 
-                    userId, card.getCardProductId(), e.getMessage());
+                log.warn("⚠️ 사용자 {}의 카드 {} ('{}') 혜택 계산 중 오류 발생, 건너뜁니다: {}", 
+                    userId, card.getCardProductId(), card.getName(), e.getMessage());
             }
         }
 
@@ -542,8 +552,8 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
             
             String message = String.format("KB국민카드에서 발급 가능한 카드 %d개를 조회했습니다.", kbCardDTOs.size());
             
-            log.info("KB국민카드 추천 완료: {} 개", kbCardDTOs.size());
-            
+             log.info("KB국민카드 추천 완료: {} 개", kbCardDTOs.size());
+
             return KbCardRecommendationResponseDTO.builder()
                 .kbCards(kbCardDTOs)
                 .totalCount(kbCardDTOs.size())

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/controller/KbCardController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/controller/KbCardController.java
@@ -20,10 +20,7 @@ import team2.pjt12.matchumoney.domain.mydata.vo.CardTransactionVO;
 import team2.pjt12.matchumoney.global.success.SuccessResponse;
 
 import javax.validation.Valid;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.*;
 
 @Slf4j
 @RestController
@@ -145,5 +142,45 @@ public class KbCardController {
                 holdingId, responseDTOList.size(), categoryStats);
 
         return ResponseEntity.ok(new SuccessResponse<>(responseDTOList, message));
+    }
+    
+    @PutMapping("/transactions/refresh/{userId}")
+    @ApiOperation(
+            value = "connectedId 기반 거래내역 업데이트",
+            notes = "connectedId를 사용하여 최근 30일 카드 거래내역을 조회하고 업데이트합니다. " +
+                    "카드번호와 비밀번호 입력 없이 connectedId만으로 모든 카드의 거래내역을 가져옵니다. " +
+                    "중복 거래내역은 자동으로 필터링되어 새로운 거래내역만 저장됩니다. " +
+                    "프론트엔드의 '내역 업데이트' 버튼과 연결됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "거래내역 업데이트 성공"),
+            @ApiResponse(code = 400, message = "connectedId가 없거나 잘못된 요청"),
+            @ApiResponse(code = 401, message = "인증 실패"),
+            @ApiResponse(code = 404, message = "사용자 카드 정보를 찾을 수 없음"),
+            @ApiResponse(code = 500, message = "MyData API 호출 실패 또는 서버 오류")
+    })
+    public ResponseEntity<SuccessResponse<List<CardTransactionResponseDTO>>> refreshTransactionsByConnectedId(
+            @ApiParam(value = "사용자 ID", required = true, example = "1")
+            @PathVariable Long userId) throws Exception {
+            
+        // 사용자 카드 목록에서 connectedId 조회
+        List<CardHoldingVO> userCards = kbCardService.getCards(userId);
+        if (userCards.isEmpty()) {
+            return ResponseEntity.badRequest().body(new SuccessResponse<>(new ArrayList<>(),
+                    "사용자의 카드 정보가 없습니다. 먼저 카드를 등록해주세요."));
+        }
+        
+        String connectedId = userCards.get(0).getConnectedId();
+        if (connectedId == null || connectedId.isEmpty()) {
+            return ResponseEntity.badRequest().body(new SuccessResponse<>(new ArrayList<>(),
+                    "connectedId가 없습니다. 카드를 다시 등록해주세요."));
+        }
+        
+        // connectedId를 사용하여 거래내역 업데이트
+        List<CardTransactionVO> updatedTransactions = kbCardService.syncTransactionsByConnectedId(userId, connectedId);
+        List<CardTransactionResponseDTO> responseDTOList = CardDTOConverter.toCardTransactionResponseDTOList(updatedTransactions);
+        
+        return ResponseEntity.ok(new SuccessResponse<>(responseDTOList,
+                String.format("최근 30일 거래내역이 업데이트되었습니다. 새로 추가된 거래내역: %d건", responseDTOList.size())));
     }
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/mapper/KbCardTransactionMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/mapper/KbCardTransactionMapper.java
@@ -39,4 +39,14 @@ public interface KbCardTransactionMapper {
      * 동일한 가맹점명을 가진 모든 거래 내역의 카테고리를 일괄 업데이트합니다.
      */
     void updateAllTransactionsCategory(@Param("merchantName") String merchantName, @Param("category") String category);
+    
+    /**
+     * 거래내역 중복 체크를 위한 메서드
+     * 사용자ID, 카드번호, 거래일, 거래시간, 승인번호를 기준으로 기존 거래내역 존재 여부 확인
+     */
+    boolean existsTransaction(@Param("userId") Long userId, 
+                            @Param("cardNo") String cardNo,
+                            @Param("usedDate") String usedDate, 
+                            @Param("usedTime") String usedTime,
+                            @Param("approvalNo") String approvalNo);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardService.java
@@ -125,4 +125,21 @@ public interface KbCardService {
      * @return 카테고리별 거래 건수 맵 (카테고리명 -> 건수)
      */
     Map<String, Long> getCategoryStatistics(List<CardTransactionVO> transactions);
+    
+    /**
+     * connectedId를 사용하여 최근 30일 카드 거래내역을 조회하고 저장합니다.
+     * 
+     * 주요 기능:
+     *   connectedId를 통해 모든 카드의 거래내역 조회
+     *   카드번호 기반으로 기존 카드 정보와 매칭
+     *   중복 거래내역 방지 (기존 데이터와 비교)
+     *   새로운 거래내역만 저장
+     *   카테고리 자동 분류 및 추천 재계산 트리거
+     * 
+     * @param userId 사용자 ID
+     * @param connectedId KB카드 마이데이터 연동 ID
+     * @return 저장된 거래 내역 목록
+     * @throws Exception 마이데이터 API 호출 실패 등
+     */
+    List<CardTransactionVO> syncTransactionsByConnectedId(Long userId, String connectedId) throws Exception;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardServiceImpl.java
@@ -156,67 +156,36 @@ public class KbCardServiceImpl implements KbCardService {
     public List<CardTransactionVO> syncAndSaveCardTransactions(
             Long userId, Long holdingId, String cardNo, String cardPw2, String birthDate, LocalDate startDate, LocalDate endDate
     ) throws Exception {
+        
+        log.info("🔄 개별 카드 업데이트 요청을 전체 카드 업데이트로 변경 - 사용자: {}, holdingId: {}", userId, holdingId);
+        
         // connectedId 가져오기 (이미 DB에 저장된 cardInfo를 통해)
-        CardHoldingVO cardInfo = kbCardMapper.selectKbCardByUserId(userId)
-                .stream()
-                .filter(card -> card.getHoldingId() != null && card.getHoldingId().equals(holdingId))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("해당 holdingId를 가진 카드를 찾을 수 없습니다."));
-
-        String connectedId = cardInfo.getConnectedId();
+        List<CardHoldingVO> userCards = kbCardMapper.selectKbCardByUserId(userId);
+        if (userCards.isEmpty()) {
+            throw new RuntimeException("사용자의 카드 정보가 없습니다. 먼저 카드를 등록해주세요.");
+        }
+        
+        String connectedId = userCards.get(0).getConnectedId();
         if (connectedId == null || connectedId.isEmpty()) {
             throw new RuntimeException("connectedId가 유효하지 않습니다. 카드 연동이 필요합니다.");
         }
 
-        // CodeF API를 통해 거래 내역 조회
-        List<CardTransactionVO> transactions = kbCardApiUtil.fetchKbCardTransactions(
-                connectedId, cardNo, cardPw2, birthDate, startDate, endDate, userId,
-                cardInfo.getFinId(), // CardHoldingVO의 finId를 CardTransactionVO의 finId로 사용
-                cardInfo.getCardId(), // CardHoldingVO의 cardId (카드고릴라 idx)를 CardTransactionVO의 cardId2로 사용
-                cardInfo.getCardName(), // CardHoldingVO의 cardName을 CardTransactionVO의 cardName으로 사용
-                holdingId // CardHoldingVO의 holdingId를 CardTransactionVO의 holdingId로 사용
-        );
-
-        // 기존 거래 내역 삭제 및 새 거래 내역 저장
-        log.debug("기존 거래 내역 삭제 시작 - holdingId: {}", holdingId);
-        kbCardTransactionMapper.deleteKbCardTransactionsByHoldingId(holdingId);
+        log.info("🔄 connectedId 기반 전체 거래내역 업데이트 시작 - 기간: {} ~ {}", startDate, endDate);
         
-        log.debug("새로운 거래 내역 저장 시작 - 총 {}건", transactions.size());
-        for (int i = 0; i < transactions.size(); i++) {
-            CardTransactionVO transaction = transactions.get(i);
-            
-            // 가맹점명을 기반으로 소비 분야 자동 분류
-            String originalMerchantName = transaction.getResMemberStoreName();
-            String category = merchantCategoryService.categorizeByMerchantName(originalMerchantName);
-            transaction.setResMemberStoreType(category);
-            
-            log.debug("거래 내역 분류 [{}/{}]: '{}' -> '{}'", 
-                    i + 1, transactions.size(), originalMerchantName, category);
-            
-            try {
-                kbCardTransactionMapper.insertKbCardTransaction(transaction);
-            } catch (Exception e) {
-                log.error("거래 내역 저장 실패 - 가맹점: '{}', 에러: {}", originalMerchantName, e.getMessage());
-                throw new RuntimeException("거래 내역 저장 중 오류가 발생했습니다: " + e.getMessage(), e);
-            }
-        }
+        // connectedId로 모든 카드의 거래내역을 업데이트 (카드번호 불필요)
+        List<CardTransactionVO> allTransactions = syncTransactionsByConnectedIdWithDateRange(userId, connectedId, startDate, endDate);
         
-        log.info("거래 내역 저장 완료 - 총 {}건 저장됨", transactions.size());
+        // 요청된 holdingId에 해당하는 거래내역만 필터링해서 반환
+        List<CardTransactionVO> filteredTransactions = allTransactions.stream()
+                .filter(transaction -> {
+                    // holdingId가 일치하는 거래내역만 반환
+                    return transaction.getHoldingId() != null && transaction.getHoldingId().equals(holdingId);
+                })
+                .collect(java.util.stream.Collectors.toList());
+                
+        log.info("✅ 전체 {}건 중 요청 카드 거래내역 {}건 반환", allTransactions.size(), filteredTransactions.size());
         
-        // 거래내역 업데이트 후 추천 카드 재계산 트리거 (비동기)
-        try {
-            if (cardInfo.getCardId() != null) { // 카드고릴라 매칭이 된 카드만
-                log.info("사용자 {}의 카드 {} 추천 재계산 트리거", userId, cardInfo.getCardId());
-                cardRecommendationRefreshService.refreshRecommendationsForUserCard(userId, cardInfo.getCardId());
-            } else {
-                log.debug("카드고릴라 매칭이 되지 않은 카드로 추천 재계산을 건너뜁니다. 카드명: {}", cardInfo.getCardName());
-            }
-        } catch (Exception e) {
-            log.warn("추천 재계산 트리거 중 오류 발생하였으나 거래내역 저장은 성공: 사용자 {}, 카드 {}", 
-                userId, cardInfo.getCardId(), e);
-        }
-        
-        return transactions;
+        return filteredTransactions;
     }
 
     @Override
@@ -238,6 +207,110 @@ public class KbCardServiceImpl implements KbCardService {
         // 최근 30일 거래내역 조회
         LocalDate endDate = LocalDate.now();
         LocalDate startDate = endDate.minusDays(30);
+        
+        log.info("connectedId를 이용한 거래내역 동기화 시작 - 사용자: {}, 기간: {} ~ {}", userId, startDate, endDate);
+        
+        // connectedId로 모든 카드의 거래내역 조회
+        List<CardTransactionVO> allTransactions = kbCardApiUtil.fetchKbCardTransactionsByConnectedId(
+                connectedId, startDate, endDate, userId);
+        
+        if (allTransactions.isEmpty()) {
+            log.info("조회된 거래내역이 없습니다.");
+            return allTransactions;
+        }
+        
+        // 사용자의 기존 카드 정보 조회 (카드번호 매칭용)
+        List<CardHoldingVO> userCards = kbCardMapper.selectKbCardByUserId(userId);
+        Map<String, CardHoldingVO> cardMap = userCards.stream()
+                .collect(java.util.stream.Collectors.toMap(CardHoldingVO::getResCardNo, card -> card));
+        
+        List<CardTransactionVO> savedTransactions = new ArrayList<>();
+        int duplicateCount = 0;
+        
+        for (CardTransactionVO transaction : allTransactions) {
+            // 중복 체크
+            boolean exists = kbCardTransactionMapper.existsTransaction(
+                    userId, 
+                    transaction.getResCardNo(),
+                    transaction.getResUsedDate(),
+                    transaction.getResUsedTime(),
+                    transaction.getResApprovalNo()
+            );
+            
+            if (exists) {
+                duplicateCount++;
+                log.debug("중복 거래내역 건너뜀: {} - {} {}", 
+                        transaction.getResMemberStoreName(), 
+                        transaction.getResUsedDate(), 
+                        transaction.getResUsedTime());
+                continue;
+            }
+            
+            // 카드번호로 기존 카드 정보와 매칭
+            CardHoldingVO matchedCard = cardMap.get(transaction.getResCardNo());
+            if (matchedCard != null) {
+                transaction.setFinId(matchedCard.getFinId());
+                transaction.setHoldingId(matchedCard.getHoldingId()); // holdingId 설정 추가
+                transaction.setCardId2(matchedCard.getCardId());
+                transaction.setCardName(matchedCard.getCardName());
+            } else {
+                log.warn("매칭되지 않은 카드번호: {} - 거래내역 저장하지만 카드 정보 누락", transaction.getResCardNo());
+                // finId, holdingId, cardId2를 null로 설정하고 저장
+                transaction.setFinId(null);
+                transaction.setHoldingId(null);
+                transaction.setCardId2(null);
+            }
+            
+            // 가맹점명 기반 카테고리 자동 분류
+            String category = merchantCategoryService.categorizeByMerchantName(transaction.getResMemberStoreName());
+            transaction.setResMemberStoreType(category);
+            
+            try {
+                kbCardTransactionMapper.insertKbCardTransaction(transaction);
+                savedTransactions.add(transaction);
+                
+                log.debug("거래내역 저장 완료: {} - {} {} ({})", 
+                        transaction.getResMemberStoreName(),
+                        transaction.getResUsedDate(),
+                        transaction.getResUsedTime(),
+                        category);
+            } catch (Exception e) {
+                log.error("거래내역 저장 실패: {} - {}", transaction.getResMemberStoreName(), e.getMessage());
+            }
+        }
+        
+        log.info("거래내역 동기화 완료 - 총 조회: {}건, 중복: {}건, 저장: {}건", 
+                allTransactions.size(), duplicateCount, savedTransactions.size());
+        
+        // 추천 재계산 트리거 (저장된 거래내역이 있는 카드들에 대해)
+        Set<Integer> affectedCardIds = savedTransactions.stream()
+                .filter(t -> t.getCardId2() != null)
+                .map(CardTransactionVO::getCardId2)
+                .collect(java.util.stream.Collectors.toSet());
+        
+        for (Integer cardId : affectedCardIds) {
+            try {
+                log.info("카드 {}에 대한 추천 재계산 트리거", cardId);
+                cardRecommendationRefreshService.refreshRecommendationsForUserCard(userId, cardId);
+            } catch (Exception e) {
+                log.warn("추천 재계산 트리거 중 오류 발생: 사용자 {}, 카드 {} - {}", userId, cardId, e.getMessage());
+            }
+        }
+        
+        return savedTransactions;
+    }
+
+    /**
+     * connectedId를 이용하여 특정 날짜 범위의 거래내역을 동기화하는 메서드
+     * @param userId 사용자 ID
+     * @param connectedId 연결 ID  
+     * @param startDate 조회 시작일
+     * @param endDate 조회 종료일
+     * @return 동기화된 거래내역 목록
+     * @throws Exception API 호출 실패시
+     */
+    public List<CardTransactionVO> syncTransactionsByConnectedIdWithDateRange(
+            Long userId, String connectedId, LocalDate startDate, LocalDate endDate) throws Exception {
         
         log.info("connectedId를 이용한 거래내역 동기화 시작 - 사용자: {}, 기간: {} ~ {}", userId, startDate, endDate);
         

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/service/KbCardServiceImpl.java
@@ -13,9 +13,7 @@ import team2.pjt12.matchumoney.domain.mydata.vo.CardTransactionVO;
 import team2.pjt12.matchumoney.domain.cardrecommendation.service.CardRecommendationRefreshService;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -33,30 +31,118 @@ public class KbCardServiceImpl implements KbCardService {
 
     @Override
     public List<CardHoldingVO> syncAndSaveCards(Long userId, String kbId, String kbPw) throws Exception {
-        List<CardHoldingVO> cards = kbCardApiUtil.fetchKbCards(kbId, kbPw, userId);
+        log.info("KB카드 정보 및 거래내역 동기화 시작 (참고 프로젝트 방식) - 사용자: {}", userId);
+        
+        // 1. KB카드 정보와 각 카드의 거래내역을 함께 조회 (참고 프로젝트 방식)
+        List<CardHoldingVO> cards = kbCardApiUtil.fetchKbCardsWithTransactions(kbId, kbPw, userId);
 
+        log.info("API 조회 완료 - 카드: {}개", cards.size());
+
+        // 2. 기존 카드 데이터 삭제
         kbCardMapper.deleteKbCardById(userId);
+        
+        // 3. 카드 정보 저장 및 매칭
         for (CardHoldingVO card : cards) {
             // MyData에서 가져온 카드명으로 카드고릴라 카드 매칭 시도
+            log.info("🔍 카드고릴라 매칭 시도: '{}' (finId: {}, holdingId: {})", 
+                card.getCardName(), card.getFinId(), card.getHoldingId());
             Optional<CardVO> matchedCard = matchCardGorillaCard(card.getCardName());
             if (matchedCard.isPresent()) {
-                // 매칭 성공 시, CardHoldingVO의 cardId 필드를 카드고릴라 카드의 card_id로 업데이트
                 card.setCardId(matchedCard.get().getCardId());
+                log.info("✅ 카드고릴라 매칭 성공: '{}' -> card_id2: {}", 
+                    card.getCardName(), matchedCard.get().getCardId());
             } else {
-                // 매칭 실패 시, null로 설정 (Foreign Key 제약조건을 피하기 위해)
-                System.out.println("⚠️ 카드고릴라에서 카드명 '" + card.getCardName() + "' 에 대한 매칭된 카드를 찾을 수 없습니다.");
-                card.setCardId(null); // 매칭 실패한 카드는 null로 설정
+                log.warn("⚠️ 카드고릴라에서 카드명 '{}'에 대한 매칭된 카드를 찾을 수 없습니다.", card.getCardName());
+                card.setCardId(null);
             }
             kbCardMapper.insertKbCard(card);
         }
         
-        // 카드 저장 후 자동으로 매칭되지 않은 카드들에 대해 매칭 시도
+        // 4. 카드 저장 후 자동으로 매칭되지 않은 카드들에 대해 매칭 시도
         try {
             cardMatchingService.matchCardHoldingsByUserId(userId);
             log.info("자동 카드 매칭 완료");
         } catch (Exception e) {
             log.error("자동 카드 매칭 실패: {}", e.getMessage(), e);
         }
+        
+        // 5. 각 카드의 거래내역 처리 (중복 방지)
+        int totalNewTransactions = 0;
+        int totalDuplicateSkipped = 0;
+        
+        for (CardHoldingVO card : cards) {
+            if (card.getTransactions() != null && !card.getTransactions().isEmpty()) {
+                log.info("카드 '{}' 거래내역 {}건 중복 체크 후 저장 시작", 
+                    card.getCardName(), card.getTransactions().size());
+                
+                int newCount = 0;
+                int duplicateCount = 0;
+                
+                for (CardTransactionVO transaction : card.getTransactions()) {
+                    // 중복 체크
+                    boolean exists = kbCardTransactionMapper.existsTransaction(
+                            userId, 
+                            transaction.getResCardNo(),
+                            transaction.getResUsedDate(),
+                            transaction.getResUsedTime(),
+                            transaction.getResApprovalNo()
+                    );
+                    
+                    if (exists) {
+                        duplicateCount++;
+                        continue;
+                    }
+                    
+                    // DB에 저장할 때 필요한 필드 설정
+                    transaction.setUserId(userId);
+                    transaction.setFinId(card.getFinId());
+                    transaction.setHoldingId(card.getHoldingId()); // holdingId 설정 추가
+                    transaction.setCardId2(card.getCardId()); // 카드고릴라 매칭 ID
+                    transaction.setCardName(card.getCardName());
+                    
+                    // 로깅 추가 - 카드 매칭 상태 확인
+                    log.info("🔍 거래내역 저장 - 카드: '{}', cardId2: {}, finId: {}, holdingId: {}", 
+                        card.getCardName(), card.getCardId(), card.getFinId(), card.getHoldingId());
+                    
+                    // 가맹점명을 기반으로 소비 분야 자동 분류
+                    String originalMerchantName = transaction.getResMemberStoreName();
+                    if (originalMerchantName != null && !originalMerchantName.isEmpty()) {
+                        String category = merchantCategoryService.categorizeByMerchantName(originalMerchantName);
+                        transaction.setResMemberStoreType(category);
+                    }
+                    
+                    try {
+                        kbCardTransactionMapper.insertKbCardTransaction(transaction);
+                        newCount++;
+                    } catch (Exception e) {
+                        log.error("거래 내역 저장 실패 - 날짜: {}, 가맹점: '{}', 금액: {}, 에러: {}", 
+                            transaction.getResUsedDate(), originalMerchantName, 
+                            transaction.getResUsedAmount(), e.getMessage());
+                    }
+                }
+                
+                totalNewTransactions += newCount;
+                totalDuplicateSkipped += duplicateCount;
+                
+                log.info("카드 '{}' 거래내역 처리 완료: 신규 {}건, 중복 스킵 {}건", 
+                    card.getCardName(), newCount, duplicateCount);
+                
+                // 추천 재계산 트리거 (카드고릴라 매칭이 된 카드만)
+                if (card.getCardId() != null && newCount > 0) {
+                    try {
+                        log.info("사용자 {}의 카드 {} 추천 재계산 트리거", userId, card.getCardId());
+                        cardRecommendationRefreshService.refreshRecommendationsForUserCard(userId, card.getCardId());
+                    } catch (Exception e) {
+                        log.warn("추천 재계산 트리거 중 오류 발생: 사용자 {}, 카드 {}", userId, card.getCardId(), e);
+                    }
+                }
+            } else {
+                log.debug("카드 '{}'에 대한 거래내역이 없습니다.", card.getCardName());
+            }
+        }
+        
+        log.info("KB카드 동기화 완료 - 사용자 {}: 카드 {}개, 신규 거래내역 {}건 추가, 중복 {}건 스킵", 
+            userId, cards.size(), totalNewTransactions, totalDuplicateSkipped);
         
         return cards;
     }
@@ -87,7 +173,8 @@ public class KbCardServiceImpl implements KbCardService {
                 connectedId, cardNo, cardPw2, birthDate, startDate, endDate, userId,
                 cardInfo.getFinId(), // CardHoldingVO의 finId를 CardTransactionVO의 finId로 사용
                 cardInfo.getCardId(), // CardHoldingVO의 cardId (카드고릴라 idx)를 CardTransactionVO의 cardId2로 사용
-                cardInfo.getCardName() // CardHoldingVO의 cardName을 CardTransactionVO의 cardName으로 사용
+                cardInfo.getCardName(), // CardHoldingVO의 cardName을 CardTransactionVO의 cardName으로 사용
+                holdingId // CardHoldingVO의 holdingId를 CardTransactionVO의 holdingId로 사용
         );
 
         // 기존 거래 내역 삭제 및 새 거래 내역 저장
@@ -144,6 +231,104 @@ public class KbCardServiceImpl implements KbCardService {
                 .collect(java.util.stream.Collectors.groupingBy(
                         CardTransactionVO::getResMemberStoreType,
                         java.util.stream.Collectors.counting()));
+    }
+
+    @Override
+    public List<CardTransactionVO> syncTransactionsByConnectedId(Long userId, String connectedId) throws Exception {
+        // 최근 30일 거래내역 조회
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(30);
+        
+        log.info("connectedId를 이용한 거래내역 동기화 시작 - 사용자: {}, 기간: {} ~ {}", userId, startDate, endDate);
+        
+        // connectedId로 모든 카드의 거래내역 조회
+        List<CardTransactionVO> allTransactions = kbCardApiUtil.fetchKbCardTransactionsByConnectedId(
+                connectedId, startDate, endDate, userId);
+        
+        if (allTransactions.isEmpty()) {
+            log.info("조회된 거래내역이 없습니다.");
+            return allTransactions;
+        }
+        
+        // 사용자의 기존 카드 정보 조회 (카드번호 매칭용)
+        List<CardHoldingVO> userCards = kbCardMapper.selectKbCardByUserId(userId);
+        Map<String, CardHoldingVO> cardMap = userCards.stream()
+                .collect(java.util.stream.Collectors.toMap(CardHoldingVO::getResCardNo, card -> card));
+        
+        List<CardTransactionVO> savedTransactions = new ArrayList<>();
+        int duplicateCount = 0;
+        
+        for (CardTransactionVO transaction : allTransactions) {
+            // 중복 체크
+            boolean exists = kbCardTransactionMapper.existsTransaction(
+                    userId, 
+                    transaction.getResCardNo(),
+                    transaction.getResUsedDate(),
+                    transaction.getResUsedTime(),
+                    transaction.getResApprovalNo()
+            );
+            
+            if (exists) {
+                duplicateCount++;
+                log.debug("중복 거래내역 건너뜀: {} - {} {}", 
+                        transaction.getResMemberStoreName(), 
+                        transaction.getResUsedDate(), 
+                        transaction.getResUsedTime());
+                continue;
+            }
+            
+            // 카드번호로 기존 카드 정보와 매칭
+            CardHoldingVO matchedCard = cardMap.get(transaction.getResCardNo());
+            if (matchedCard != null) {
+                transaction.setFinId(matchedCard.getFinId());
+                transaction.setHoldingId(matchedCard.getHoldingId()); // holdingId 설정 추가
+                transaction.setCardId2(matchedCard.getCardId());
+                transaction.setCardName(matchedCard.getCardName());
+            } else {
+                log.warn("매칭되지 않은 카드번호: {} - 거래내역 저장하지만 카드 정보 누락", transaction.getResCardNo());
+                // finId, holdingId, cardId2를 null로 설정하고 저장
+                transaction.setFinId(null);
+                transaction.setHoldingId(null);
+                transaction.setCardId2(null);
+            }
+            
+            // 가맹점명 기반 카테고리 자동 분류
+            String category = merchantCategoryService.categorizeByMerchantName(transaction.getResMemberStoreName());
+            transaction.setResMemberStoreType(category);
+            
+            try {
+                kbCardTransactionMapper.insertKbCardTransaction(transaction);
+                savedTransactions.add(transaction);
+                
+                log.debug("거래내역 저장 완료: {} - {} {} ({})", 
+                        transaction.getResMemberStoreName(),
+                        transaction.getResUsedDate(),
+                        transaction.getResUsedTime(),
+                        category);
+            } catch (Exception e) {
+                log.error("거래내역 저장 실패: {} - {}", transaction.getResMemberStoreName(), e.getMessage());
+            }
+        }
+        
+        log.info("거래내역 동기화 완료 - 총 조회: {}건, 중복: {}건, 저장: {}건", 
+                allTransactions.size(), duplicateCount, savedTransactions.size());
+        
+        // 추천 재계산 트리거 (저장된 거래내역이 있는 카드들에 대해)
+        Set<Integer> affectedCardIds = savedTransactions.stream()
+                .filter(t -> t.getCardId2() != null)
+                .map(CardTransactionVO::getCardId2)
+                .collect(java.util.stream.Collectors.toSet());
+        
+        for (Integer cardId : affectedCardIds) {
+            try {
+                log.info("카드 {}에 대한 추천 재계산 트리거", cardId);
+                cardRecommendationRefreshService.refreshRecommendationsForUserCard(userId, cardId);
+            } catch (Exception e) {
+                log.warn("추천 재계산 트리거 중 오류 발생: 사용자 {}, 카드 {} - {}", userId, cardId, e.getMessage());
+            }
+        }
+        
+        return savedTransactions;
     }
 
     /**

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/util/KBCardApiUtil.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/util/KBCardApiUtil.java
@@ -21,9 +21,7 @@ import java.security.Security;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Component
 public class KBCardApiUtil {
@@ -51,22 +49,63 @@ public class KBCardApiUtil {
 
         return getCardList(token, connectedId, userId);
     }
-
-    // 카드 거래 내역 조회 메서드 추가
-    public List<CardTransactionVO> fetchKbCardTransactions(
-            String connectedId, String cardNo, String cardPw2, String birthDate, LocalDate startDate, LocalDate endDate,
-            Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding) throws Exception { // cardInfoFinId, cardInfoCardId 추가
+    
+    // 카드 목록과 거래내역을 함께 조회하는 메서드 (참고 프로젝트 방식 적용)
+    public List<CardHoldingVO> fetchKbCardsWithTransactions(String kbId, String kbPw, Long userId) throws Exception {
         String token = getAccessToken();
         if (token == null) throw new RuntimeException("CODEF 인증 실패");
 
-        // CodeF API 요청에 필요한 값 준비 (카드번호는 평문, 비밀번호만 암호화)
-//        System.out.println("원본 카드번호 길이: " + cardNo.length() + ", 값: " + cardNo);
-//        System.out.println("원본 카드비밀번호: " + cardPw2);
+        String encryptedPw = encryptRSA(kbPw);
+        String connectedId = createConnectedId(token, encryptedPw, ORG_CODE, kbId);
+        if (connectedId == null) throw new RuntimeException("connectedId 발급 실패");
+
+        // 1. 카드 목록 조회
+        List<CardHoldingVO> cards = getCardList(token, connectedId, userId);
+        System.out.println("🔍 조회된 카드 수: " + cards.size());
+        
+        // 2. 각 카드별로 거래내역 조회 (최근 30일)
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(30);
+        
+        for (CardHoldingVO card : cards) {
+            try {
+                System.out.println("🔍 카드 " + card.getCardName() + " (카드번호: " + card.getResCardNo() + ") 거래내역 조회 시작");
+                List<CardTransactionVO> transactions = getApprovalListWithCardInfo(
+                    token, connectedId, startDate, endDate, userId, 
+                    card.getFinId(), card.getCardId(), card.getCardName(), card.getResCardNo(), card.getHoldingId()
+                );
+                card.setTransactions(transactions);
+                System.out.println("✅ 카드 " + card.getCardName() + " 거래내역 " + transactions.size() + "건 조회 완료");
+            } catch (Exception e) {
+                System.out.println("❌ 카드 " + card.getCardName() + " 거래내역 조회 실패: " + e.getMessage());
+                e.printStackTrace();
+                card.setTransactions(new ArrayList<>());
+            }
+        }
+        
+        return cards;
+    }
+
+    // 카드 거래 내역 조회 메서드 (기존 - 카드번호/비밀번호 필요)
+    public List<CardTransactionVO> fetchKbCardTransactions(
+            String connectedId, String cardNo, String cardPw2, String birthDate, LocalDate startDate, LocalDate endDate,
+            Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding, Long holdingId) throws Exception {
+        String token = getAccessToken();
+        if (token == null) throw new RuntimeException("CODEF 인증 실패");
+
         String encryptedCardPw2 = encryptRSA(cardPw2);
-//        System.out.println("생년월일: " + birthDate);
 
         return getApprovalList(token, connectedId, birthDate, startDate, endDate,
-                cardNo, encryptedCardPw2, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding);
+                cardNo, encryptedCardPw2, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, holdingId);
+    }
+
+    // connectedId만으로 카드 거래 내역 조회 (신규 메서드)
+    public List<CardTransactionVO> fetchKbCardTransactionsByConnectedId(
+            String connectedId, LocalDate startDate, LocalDate endDate, Long userId) throws Exception {
+        String token = getAccessToken();
+        if (token == null) throw new RuntimeException("CODEF 인증 실패");
+
+        return getApprovalListByConnectedId(token, connectedId, startDate, endDate, userId);
     }
 
     private String getAccessToken() throws Exception {
@@ -230,7 +269,7 @@ public class KBCardApiUtil {
     // 카드 승인내역(거래내역) 조회 및 파싱 메서드
     private List<CardTransactionVO> getApprovalList(
             String token, String connectedId, String birthDate, LocalDate startDate, LocalDate endDate,
-            String cardNo, String encryptedCardPw2, Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding) throws Exception {
+            String cardNo, String encryptedCardPw2, Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding, Long holdingId) throws Exception {
 
         List<CardTransactionVO> transactions = new ArrayList<>();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -279,7 +318,7 @@ public class KBCardApiUtil {
         if (dataNode.isArray()) {
             System.out.println("✅ 승인내역 " + dataNode.size() + "건 발견!");
             for (JsonNode approval : dataNode) {
-                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate));
+                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
             }
         } 
         // data.list가 배열인 경우
@@ -287,13 +326,13 @@ public class KBCardApiUtil {
             JsonNode listNode = dataNode.get("list");
             System.out.println("✅ 승인내역 " + listNode.size() + "건 발견!");
             for (JsonNode approval : listNode) {
-                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate));
+                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
             }
         }
         // data가 단일 객체인 경우
         else if (dataNode.isObject() && dataNode.has("resUsedAmount")) {
             System.out.println("✅ 승인내역 1건 발견!");
-            transactions.add(parseTransactionNode(dataNode, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate));
+            transactions.add(parseTransactionNode(dataNode, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
         } 
         else {
             System.out.println("❌ 승인내역 없음 또는 예상치 못한 응답 형식!");
@@ -302,12 +341,291 @@ public class KBCardApiUtil {
         return transactions;
     }
 
+    // connectedId만으로 카드 승인내역 조회 (신규 메서드)
+    private List<CardTransactionVO> getApprovalListByConnectedId(
+            String token, String connectedId, LocalDate startDate, LocalDate endDate, Long userId) throws Exception {
+
+        List<CardTransactionVO> transactions = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        String inputJson = String.format(
+                """
+                {
+                    "organization": "%s",
+                    "connectedId": "%s",
+                    "birthDate": "",
+                    "startDate": "%s",
+                    "endDate": "%s",
+                    "orderBy": "0",
+                    "inquiryType": "%s",
+                    "cardName": "",
+                    "duplicateCardIdx": "",
+                    "cardNo": "",
+                    "cardPassword": "",
+                    "memberStoreInfoType": ""
+                }
+                """, ORG_CODE, connectedId,
+                startDate.format(formatter), endDate.format(formatter),
+                INQUIRY_TYPE_APPROVAL_LIST);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("https://development.codef.io/v1/kr/card/p/account/approval-list"))
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(inputJson))
+                .build();
+
+        HttpResponse<String> res = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        String decoded = URLDecoder.decode(res.body(), StandardCharsets.UTF_8);
+
+        System.out.println("\n📥 CODEF 카드 승인내역 API 응답 (connectedId 기반):\n" + decoded);
+
+        JsonNode rootNode = new ObjectMapper().readTree(decoded);
+        
+        // 응답 구조 로깅
+        System.out.println("📊 응답 루트 노드 키들: " + rootNode.fieldNames().next());
+        
+        // result 코드 확인
+        if (rootNode.has("result")) {
+            JsonNode resultNode = rootNode.get("result");
+            System.out.println("📋 Result 정보: " + resultNode.toString());
+            
+            if (resultNode.has("code") && !resultNode.get("code").asText().equals("CF-00000")) {
+                System.out.println("❌ API 오류 발생: " + resultNode.get("message").asText());
+                return transactions;
+            }
+        }
+        
+        JsonNode dataNode = rootNode.get("data");
+        if (dataNode == null || dataNode.isNull()) {
+            System.out.println("❌ 승인내역 없음 또는 API 오류 (data 노드 누락)!");
+            System.out.println("🔍 전체 응답 구조 분석:");
+            rootNode.fieldNames().forEachRemaining(fieldName -> {
+                System.out.println("  - " + fieldName + ": " + rootNode.get(fieldName).getNodeType());
+            });
+            return transactions;
+        }
+
+        System.out.println("🔍 Data 노드 타입: " + dataNode.getNodeType());
+        System.out.println("🔍 Data 노드 내용 (처음 500자): " + dataNode.toString().substring(0, Math.min(500, dataNode.toString().length())));
+
+        // data가 배열인 경우
+        if (dataNode.isArray()) {
+            System.out.println("✅ 승인내역 " + dataNode.size() + "건 발견! (배열 형태)");
+            for (JsonNode approval : dataNode) {
+                CardTransactionVO transaction = parseConnectedIdTransactionNode(approval, userId, startDate, endDate);
+                if (transaction != null) {
+                    transactions.add(transaction);
+                }
+            }
+        } 
+        // data가 객체이고 배열 필드를 가진 경우 (다양한 필드명 고려)
+        else if (dataNode.isObject()) {
+            JsonNode arrayNode = null;
+            String[] possibleArrayFields = {"list", "resList", "resApprovalList", "cardApprovalList"};
+            
+            for (String fieldName : possibleArrayFields) {
+                if (dataNode.has(fieldName) && dataNode.get(fieldName).isArray()) {
+                    arrayNode = dataNode.get(fieldName);
+                    System.out.println("✅ 승인내역 " + arrayNode.size() + "건 발견! (객체." + fieldName + " 배열)");
+                    break;
+                }
+            }
+            
+            if (arrayNode != null) {
+                for (JsonNode approval : arrayNode) {
+                    CardTransactionVO transaction = parseConnectedIdTransactionNode(approval, userId, startDate, endDate);
+                    if (transaction != null) {
+                        transactions.add(transaction);
+                    }
+                }
+            }
+            // data가 단일 거래내역인 경우
+            else if (dataNode.has("resUsedAmount") || dataNode.has("resMemberStoreName")) {
+                System.out.println("✅ 승인내역 1건 발견! (단일 객체)");
+                CardTransactionVO transaction = parseConnectedIdTransactionNode(dataNode, userId, startDate, endDate);
+                if (transaction != null) {
+                    transactions.add(transaction);
+                }
+            }
+            else {
+                System.out.println("❌ 인식할 수 있는 승인내역 배열을 찾을 수 없습니다.");
+                System.out.println("🔍 Data 객체의 필드들:");
+                dataNode.fieldNames().forEachRemaining(fieldName -> {
+                    System.out.println("  - " + fieldName + ": " + dataNode.get(fieldName).getNodeType());
+                });
+            }
+        }
+        else {
+            System.out.println("❌ 예상치 못한 data 노드 형식: " + dataNode.getNodeType());
+        }
+        return transactions;
+    }
+
+    // 카드별 거래내역 조회 메서드 (참고 프로젝트 방식)
+    private List<CardTransactionVO> getApprovalListWithCardInfo(
+            String token, String connectedId, LocalDate startDate, LocalDate endDate,
+            Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding, String cardNo, Long holdingId) throws Exception {
+
+        List<CardTransactionVO> transactions = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        String inputJson = String.format(
+                """
+                {
+                    "organization": "%s",
+                    "connectedId": "%s",
+                    "birthDate": "",
+                    "startDate": "%s",
+                    "endDate": "%s",
+                    "orderBy": "0",
+                    "inquiryType": "%s",
+                    "cardName": "%s",
+                    "duplicateCardIdx": "",
+                    "cardNo": "%s",
+                    "cardPassword": "",
+                    "memberStoreInfoType": ""
+                }
+                """, ORG_CODE, connectedId,
+                startDate.format(formatter), endDate.format(formatter),
+                INQUIRY_TYPE_APPROVAL_LIST, cardNameFromHolding, cardNo);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("https://development.codef.io/v1/kr/card/p/account/approval-list"))
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(inputJson))
+                .build();
+
+        HttpResponse<String> res = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        String decoded = URLDecoder.decode(res.body(), StandardCharsets.UTF_8);
+
+        System.out.println("\n📥 CODEF 카드 승인내역 API 응답 (카드별 조회 - " + cardNameFromHolding + "):\n" + decoded);
+
+        JsonNode rootNode = new ObjectMapper().readTree(decoded);
+        JsonNode dataNode = rootNode.get("data");
+
+        if (dataNode == null || dataNode.isNull()) {
+            System.out.println("❌ 승인내역 없음 또는 API 오류 (data 노드 누락)!");
+            return transactions;
+        }
+
+        if (dataNode.isArray()) {
+            System.out.println("✅ " + cardNameFromHolding + " 승인내역 " + dataNode.size() + "건 발견!");
+            for (JsonNode approval : dataNode) {
+                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
+            }
+        } 
+        else if (dataNode.isObject() && dataNode.has("list") && dataNode.get("list").isArray()) {
+            JsonNode listNode = dataNode.get("list");
+            System.out.println("✅ " + cardNameFromHolding + " 승인내역 " + listNode.size() + "건 발견!");
+            for (JsonNode approval : listNode) {
+                transactions.add(parseTransactionNode(approval, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
+            }
+        }
+        else if (dataNode.isObject() && dataNode.has("resUsedAmount")) {
+            System.out.println("✅ " + cardNameFromHolding + " 승인내역 1건 발견!");
+            transactions.add(parseTransactionNode(dataNode, userId, cardInfoFinId, cardInfoCardId, cardNameFromHolding, startDate, endDate, holdingId));
+        } 
+        else {
+            System.out.println("❌ " + cardNameFromHolding + " 승인내역 없음 또는 예상치 못한 응답 형식!");
+            System.out.println("data 구조: " + dataNode.toString());
+        }
+        return transactions;
+    }
+
+    // connectedId 기반 거래내역 파싱 메서드
+    private CardTransactionVO parseConnectedIdTransactionNode(
+            JsonNode approval, Long userId, LocalDate commStartDate, LocalDate commEndDate) {
+        
+        try {
+            // 필수 필드 검증 (거래일과 가맹점명이 없으면 무효한 거래내역으로 간주)
+            String usedDate = approval.path("resUsedDate").asText("");
+            String merchantName = approval.path("resMemberStoreName").asText("");
+            
+            if (usedDate.isEmpty() && merchantName.isEmpty()) {
+                System.out.println("⚠️ 필수 필드가 누락된 거래내역을 건너뜀: " + approval.toString());
+                return null;
+            }
+            
+            CardTransactionVO vo = new CardTransactionVO();
+
+            // connectedId로 조회한 경우 finId와 cardId2는 나중에 설정
+            vo.setFinId(null);
+            vo.setCardId2(null);
+            vo.setUserId(userId);
+            vo.setCardName(approval.path("resCardName").asText(""));
+
+            // 필수 필드에 대한 null/empty 체크 및 기본값 설정
+            vo.setResUsedDate(usedDate);
+            vo.setResUsedTime(approval.path("resUsedTime").asText(""));
+            vo.setResCardNo(approval.path("resCardNo").asText(""));
+            vo.setResCardNo1(approval.path("resCardNo1").asText(null));
+            vo.setResCardName(approval.path("resCardName").asText(""));
+            vo.setResMemberStoreName(merchantName);
+            
+            // 금액 필드 안전한 파싱
+            vo.setResUsedAmount(parseAmountSafely(approval.path("resUsedAmount")));
+            vo.setResPaymentType(approval.path("resPaymentType").asText(""));
+            vo.setResInstallmentMonth(approval.path("resInstallmentMonth").asText(null));
+            vo.setResApprovalNo(approval.path("resApprovalNo").asText(""));
+            vo.setResPaymentDueDate(approval.path("resPaymentDueDate").asText(null));
+            vo.setResHomeForeignType(approval.path("resHomeForeignType").asText(""));
+            vo.setResMemberStoreCorpNo(approval.path("resMemberStoreCorpNo").asText(null));
+            vo.setResMemberStoreType(approval.path("resMemberStoreType").asText(null));
+            vo.setResMemberStoreTelNo(approval.path("resMemberStoreTelNo").asText(null));
+            vo.setResMemberStoreAddr(approval.path("resMemberStoreAddr").asText(null));
+            vo.setResMemberStoreNo(approval.path("resMemberStoreNo").asText(null));
+            
+            // 취소 여부 확인 (대소문자, 다양한 값 고려)
+            String cancelYn = approval.path("resCancelYN").asText("N").toUpperCase();
+            vo.setResCancelYn(cancelYn.equals("Y") || cancelYn.equals("1") ? "Y" : "N");
+            
+            vo.setResCancelAmount(parseAmountSafely(approval.path("resCancelAmount")));
+            vo.setResVat(parseAmountSafely(approval.path("resVat")));
+            vo.setResCashBack(parseAmountSafely(approval.path("resCashBack")));
+            vo.setResKrwAmt(parseAmountSafely(approval.path("resKrwAmt")));
+            vo.setResAccountCurrency(approval.path("resAccountCurrency").asText("KRW"));
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+            vo.setCommStartDate(commStartDate.format(formatter));
+            vo.setCommEndDate(commEndDate.format(formatter));
+
+            return vo;
+            
+        } catch (Exception e) {
+            System.out.println("❌ 거래내역 파싱 중 오류 발생: " + e.getMessage());
+            System.out.println("🔍 문제가 된 JSON: " + approval.toString());
+            return null;
+        }
+    }
+    
+    // 금액 필드를 안전하게 파싱하는 헬퍼 메서드
+    private Long parseAmountSafely(JsonNode amountNode) {
+        if (amountNode.isMissingNode() || amountNode.isNull()) {
+            return 0L;
+        }
+        
+        try {
+            if (amountNode.isNumber()) {
+                return amountNode.asLong();
+            }
+            
+            String amountStr = amountNode.asText().replaceAll("[^0-9-]", "");
+            return amountStr.isEmpty() ? 0L : Long.parseLong(amountStr);
+        } catch (NumberFormatException e) {
+            System.out.println("⚠️ 금액 파싱 실패: " + amountNode.toString() + " -> 0으로 설정");
+            return 0L;
+        }
+    }
+
     private CardTransactionVO parseTransactionNode(
             JsonNode approval, Long userId, Long cardInfoFinId, Integer cardInfoCardId, String cardNameFromHolding, // 매개변수 수정
-            LocalDate commStartDate, LocalDate commEndDate) {
+            LocalDate commStartDate, LocalDate commEndDate, Long holdingId) {
         CardTransactionVO vo = new CardTransactionVO();
 
         vo.setFinId(cardInfoFinId); // CardHoldingVO의 finId 값으로 설정
+        vo.setHoldingId(holdingId); // CardHoldingVO의 holdingId 값으로 설정
         // 매칭 실패시 null 허용 (외래키 제약조건 해제 후)
         vo.setCardId2(cardInfoCardId); // CardHoldingVO의 cardId (카드고릴라 idx) 값으로 설정, null 가능
         vo.setUserId(userId);

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/vo/CardHoldingVO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/vo/CardHoldingVO.java
@@ -3,6 +3,7 @@ package team2.pjt12.matchumoney.domain.mydata.vo;
 import lombok.*;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 @Getter
 @Setter
@@ -27,4 +28,7 @@ public class CardHoldingVO {
     private Timestamp lastModifiedTime;
     private Long userId;
     private String connectedId; // 마이데이터 발급 ID
+    
+    // 통합 조회 시 거래내역을 담기 위한 임시 필드 (DB 저장 안됨)
+    private List<CardTransactionVO> transactions;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/mydata/vo/CardTransactionVO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/mydata/vo/CardTransactionVO.java
@@ -12,6 +12,7 @@ import java.sql.Timestamp;
 public class CardTransactionVO {
     private Long transactionId;
     private Long finId;
+    private Long holdingId; // mydata_card_holdings의 holding_id
     private Integer cardId2; // mydata_card_holdings의 card_id (카드고릴라 idx)
     private Long userId;
     private String cardName; // 카드고릴라 기준 카드 이름 (CardInfoVO에서 가져옴)

--- a/src/main/resources/mapper/CardRecommendationMapper.xml
+++ b/src/main/resources/mapper/CardRecommendationMapper.xml
@@ -38,15 +38,15 @@
         AND res_cancel_yn = 'N'
     </select>
 
-    <!-- 사용자가 보유한 카드 정보 조회 -->
+    <!-- 사용자가 보유한 카드 정보 조회 (매칭되지 않은 카드도 포함) -->
     <select id="selectUserOwnedCards" resultType="team2.pjt12.matchumoney.domain.cardrecommendation.vo.CardProductVO">
         SELECT 
-            cp.card_product_id as cardProductId,
-            cp.name,
-            cp.type,
-            cp.is_available as isAvailable,
+            COALESCE(cp.card_product_id, mch.card_id) as cardProductId,
+            COALESCE(cp.name, mch.card_name) as name,
+            COALESCE(cp.type, '신용') as type,
+            COALESCE(cp.is_available, 1) as isAvailable,
             cp.issuer_id as issuerId,
-            cp.annual_fee as annualFee,
+            COALESCE(cp.annual_fee, 0) as annualFee,
             cp.pre_month_money as preMonthMoney,
             cp.online_only as onlineOnly,
             cp.card_image_url as cardImageUrl,
@@ -59,11 +59,12 @@
             cp.created_time as createdTime,
             cp.last_modified_time as lastModifiedTime,
             cp.persona_id as personaId,
-            cp.issuer
-        FROM card_product cp
-        INNER JOIN mydata_card_holdings mch ON cp.card_product_id = mch.card_id
+            COALESCE(cp.issuer, '기타') as issuer
+        FROM mydata_card_holdings mch
+        LEFT JOIN card_product cp ON cp.card_product_id = mch.card_id
         WHERE mch.user_id = #{userId}
         AND mch.res_state = '정상'  -- 정상 상태인 카드만
+        ORDER BY mch.card_id DESC  -- 최근 등록순
     </select>
 
     <!-- 카드 타입별 발급 가능한 카드 목록 조회 -->
@@ -171,43 +172,46 @@
         WHERE card_product_id = #{cardId}
     </select>
 
-    <!-- 사용자의 특정 카드 거래내역 기반 카테고리별 통계 조회 -->
+    <!-- 사용자의 특정 카드 거래내역 기반 카테고리별 통계 조회 - holding_id 기준으로 수정 -->
     <select id="selectTransactionSummaryByUserAndCard" resultType="team2.pjt12.matchumoney.domain.cardrecommendation.vo.CardTransactionSummaryVO">
         SELECT 
             COALESCE(
-                NULLIF(TRIM(res_member_store_type), ''), 
+                NULLIF(TRIM(mct.res_member_store_type), ''), 
                 '기타'
             ) as category,
-            SUM(res_used_amount) as totalAmount,
+            SUM(mct.res_used_amount) as totalAmount,
             COUNT(*) as transactionCount,
-            AVG(res_used_amount) as averageAmount,
-            ROUND((SUM(res_used_amount) * 100.0 / (
-                SELECT SUM(res_used_amount) 
-                FROM mydata_card_transactions 
-                WHERE user_id = #{userId} 
-                AND card_id2 = #{cardId}
-                AND res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') 
+            AVG(mct.res_used_amount) as averageAmount,
+            ROUND((SUM(mct.res_used_amount) * 100.0 / (
+                SELECT SUM(t2.res_used_amount) 
+                FROM mydata_card_transactions t2
+                INNER JOIN mydata_card_holdings h2 ON t2.holding_id = h2.holding_id
+                WHERE t2.user_id = #{userId} 
+                AND h2.card_id = #{cardId}
+                AND t2.res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') 
                 AND DATE_FORMAT(#{endDate}, '%Y%m%d')
-                AND res_cancel_yn = '0'
+                AND t2.res_cancel_yn IN ('N', '0')
             )), 2) as categoryRatio
-        FROM mydata_card_transactions
-        WHERE user_id = #{userId}
-        AND card_id2 = #{cardId}
-        AND res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
-        AND res_cancel_yn = '0'  -- 취소되지 않은 거래만
+        FROM mydata_card_transactions mct
+        INNER JOIN mydata_card_holdings mch ON mct.holding_id = mch.holding_id
+        WHERE mct.user_id = #{userId}
+        AND mch.card_id = #{cardId}  -- card_product_id로 조회
+        AND mct.res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
+        AND mct.res_cancel_yn IN ('N', '0')  -- 취소되지 않은 거래만
         GROUP BY category
         HAVING totalAmount > 0
         ORDER BY totalAmount DESC
     </select>
 
-    <!-- 사용자의 특정 카드 지난 30일 총 거래액 조회 -->
+    <!-- 사용자의 특정 카드 지난 30일 총 거래액 조회 - holding_id 기준으로 수정 -->
     <select id="selectTotalSpendByUserAndCard" resultType="long">
-        SELECT COALESCE(SUM(res_used_amount), 0) as totalSpend
-        FROM mydata_card_transactions
-        WHERE user_id = #{userId}
-        AND card_id2 = #{cardId}
-        AND res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
-        AND res_cancel_yn = 'N'
+        SELECT COALESCE(SUM(mct.res_used_amount), 0) as totalSpend
+        FROM mydata_card_transactions mct
+        INNER JOIN mydata_card_holdings mch ON mct.holding_id = mch.holding_id
+        WHERE mct.user_id = #{userId}
+        AND mch.card_id = #{cardId}  -- card_product_id로 조회
+        AND mct.res_used_date BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
+        AND mct.res_cancel_yn IN ('N', '0')
     </select>
 
     <!-- ===== 추천 카드 저장/관리 쿼리들 ===== -->

--- a/src/main/resources/mapper/KbCardTransactionMapper.xml
+++ b/src/main/resources/mapper/KbCardTransactionMapper.xml
@@ -5,7 +5,7 @@
     <!-- 거래 내역 삽입 (카테고리 포함) -->
     <insert id="insertKbCardTransaction" parameterType="team2.pjt12.matchumoney.domain.mydata.vo.CardTransactionVO">
         INSERT INTO mydata_card_transactions (
-            fin_id, card_id2, user_id, card_name, res_used_date, res_used_time,
+            fin_id, holding_id, card_id2, user_id, card_name, res_used_date, res_used_time,
             res_card_no, res_card_no1, res_card_name, res_member_store_name,
             res_used_amount, res_payment_type, res_installment_month, res_approval_no,
             res_payment_due_date, res_home_foreign_type, res_member_store_corp_no,
@@ -14,7 +14,7 @@
             res_cash_back, res_krw_amt, comm_start_date, comm_end_date,
             res_account_currency, created_time, last_modified_time
         ) VALUES (
-            #{finId}, #{cardId2}, #{userId}, #{cardName}, #{resUsedDate}, #{resUsedTime},
+            #{finId}, #{holdingId}, #{cardId2}, #{userId}, #{cardName}, #{resUsedDate}, #{resUsedTime},
             #{resCardNo}, #{resCardNo1}, #{resCardName}, #{resMemberStoreName},
             #{resUsedAmount}, #{resPaymentType}, #{resInstallmentMonth}, #{resApprovalNo},
             #{resPaymentDueDate}, #{resHomeForeignType}, #{resMemberStoreCorpNo},
@@ -37,6 +37,7 @@
         SELECT
             transaction_id,
             fin_id,
+            holding_id,
             card_id2,
             user_id,
             card_name,
@@ -88,6 +89,7 @@
         SELECT
             transaction_id,
             fin_id,
+            holding_id,
             card_id2,
             user_id,
             card_name,
@@ -132,5 +134,16 @@
         WHERE res_member_store_name = #{merchantName}
         AND (res_member_store_type IS NULL OR res_member_store_type = '')
     </update>
+    
+    <!-- 거래내역 중복 체크 -->
+    <select id="existsTransaction" parameterType="map" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM mydata_card_transactions
+        WHERE user_id = #{userId}
+        AND res_card_no = #{cardNo}
+        AND res_used_date = #{usedDate}
+        AND res_used_time = #{usedTime}
+        AND res_approval_no = #{approvalNo}
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] connectedid를 이용하여 보유 카드 리스트 거래내역 한번에 조회

---

## 📎 관련 이슈
- Closes #106

---

## 🛠 작업 내용
- connectedId를 이용하여 보유카드와 거래내역을 한번에 조회할 수 있도록 로직을 변경 및 추가
- 기존에 카드 번화와 비밀번호 두자리 입력하는 로직은 남아 있음 -> 특정 카드에서 조회가 안되는 경우 이 방법을 사용할 예정
- 거래내역만을 발급은 받은 connectedId를 통하여 최근 30일 치의 거래내역을 업데이트 가능



