### PR TITLE
[Feat] 카드 검색 무한스크롤 API 구현

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/controller/CardSearchController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/controller/CardSearchController.java
@@ -1,11 +1,17 @@
 package team2.pjt12.matchumoney.domain.cardsearch.controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CardListItemDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchRequestDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchResponseDTO;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CursorPageResponse;
 import team2.pjt12.matchumoney.domain.cardsearch.service.CardSearchService;
+import team2.pjt12.matchumoney.global.util.SecurityUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,12 +19,18 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/persona")
 @RequiredArgsConstructor
+@Api(tags = "Card Search", description = "카드 검색 API")
 public class CardSearchController {
-
     private final CardSearchService cardSearchService;
 
     @PostMapping("/cardsearch")
-    public ResponseEntity<List<CardSearchResponseDTO>> searchCards(@RequestBody CardSearchRequestDTO request) {
+    @ApiOperation(
+            value = "카드 검색(전체 반환)",
+            notes = "신용/체크 여부 및 혜택 선택 조건에 따라 카드를 검색해 한 번에 모두 반환합니다."
+    )
+    public ResponseEntity<List<CardSearchResponseDTO>> searchCards(
+            @ApiParam(value = "검색 조건(신용/체크/혜택 목록)", required = true)
+            @RequestBody CardSearchRequestDTO request) {
         if (request.getSelectedBenefits() == null) {
             request = new CardSearchRequestDTO(
                     request.isCreditCard(),
@@ -29,5 +41,20 @@ public class CardSearchController {
 
         List<CardSearchResponseDTO> result = cardSearchService.searchCards(request);
         return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/infinite")
+    @ApiOperation(
+            value = "카드 검색(커서 기반 무한스크롤)",
+            notes = "커서 기반 페이지네이션으로 카드를 검색합니다."
+    )
+    public CursorPageResponse<CardListItemDTO> searchInfinite(
+            @RequestParam(required = false) String cursor,     // 마지막 커서(다음 페이지 시작점)
+            @RequestParam(defaultValue = "6") int size,        // 페이지 기본 6개
+            @ApiParam(value = "검색 조건(신용/체크/혜택 목록)", required = true)
+            @RequestBody CardSearchRequestDTO req
+    ) {
+        Long userId = SecurityUtils.getCurrentUser().getUserId();
+        return cardSearchService.searchInfinite(userId, req, cursor, size);
     }
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardListItemDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardListItemDTO.java
@@ -1,0 +1,29 @@
+package team2.pjt12.matchumoney.domain.cardsearch.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ApiModel(description = "카드 무한스크롤 목록에 노출되는 최소 카드 정보")
+public class CardListItemDTO {
+    @ApiModelProperty(value = "카드 상품 ID", example = "10")
+    private Long id;
+
+    @ApiModelProperty(value = "카드명", example = "신한 Deep Dream 카드")
+    private String name;
+
+    @ApiModelProperty(value = "카드사", example = "신한카드")
+    private String issuer;
+
+    @ApiModelProperty(value = "전월 실적 금액", example = "300000")
+    private Integer preMonthMoney;
+
+    @ApiModelProperty(value = "연회비", example = "[국내전용] 12,000원 / [해외겸용] 15,000원")
+    private String annualFee;
+
+    @ApiModelProperty(value = "카드 이미지 URL", example = "https://cdn.example.com/card/2835.png")
+    private String imageUrl;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchRequestDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchRequestDTO.java
@@ -1,5 +1,7 @@
 package team2.pjt12.matchumoney.domain.cardsearch.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,8 +11,14 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ApiModel(description = "카드 검색 요청 파라미터")
 public class CardSearchRequestDTO {
+    @ApiModelProperty(value = "신용카드 포함 여부", example = "true")
     private boolean creditCard;
+
+    @ApiModelProperty(value = "체크카드 포함 여부", example = "true")
     private boolean debitCard;
+
+    @ApiModelProperty(value = "선택한 혜택명 목록", example = "[\"교통\", \"카페/디저트\", \"통신\"]")
     private List<String> selectedBenefits;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CardSearchResponseDTO.java
@@ -1,5 +1,7 @@
 package team2.pjt12.matchumoney.domain.cardsearch.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 import team2.pjt12.matchumoney.domain.carddetail.dto.CardOptionDTO;
 
@@ -10,16 +12,51 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ApiModel(description = "카드 검색 결과 DTO")
 public class CardSearchResponseDTO {
-    private Long id;             // 카드 ID
-    private String name;         // 카드 이름
-    private String type;         // 카드 종류 (신용/체크)
-    private String imageUrl;     // 카드 이미지 URL
-    private String issuer;       // 카드사
-    private String annualFee;   // 연회비
-    private Integer preMonthMoney; // 전월 실적
+    @ApiModelProperty(value = "카드 상품 ID", example = "10", position = 1)
+    private Long id;
+
+    @ApiModelProperty(value = "카드명", example = "신한 Deep Dream 카드", position = 2)
+    private String name;
+
+    @ApiModelProperty(
+            value = "카드 종류 (신용/체크)",
+            allowableValues = "신용, 체크",
+            example = "신용",
+            position = 3
+    )
+    private String type;
+
+    @ApiModelProperty(
+            value = "카드 이미지 URL",
+            example = "https://cdn.example.com/cards/101.png",
+            position = 4
+    )
+    private String imageUrl;
+
+    @ApiModelProperty(value = "카드사", example = "신한카드", position = 5)
+    private String issuer;
+
+    @ApiModelProperty(value = "연회비", example = "[국내] 10,000원 / [해외] 15,000원", position = 6)
+    private String annualFee;
+
+    @ApiModelProperty(value = "전월 실적", example = "300000", position = 7)
+    private Integer preMonthMoney;
+
+    @ApiModelProperty(
+            value = "주요 혜택 옵션 리스트",
+            notes = "각 옵션에는 혜택명, 한도, 전월 실적 조건 등이 포함됩니다.",
+            position = 8
+    )
     private List<CardOptionDTO> options;
+
+    @ApiModelProperty(value = "즐겨찾기 여부", example = "true", position = 9)
     private Boolean isStarred;
+
+    @ApiModelProperty(value = "좋아요 수", example = "42", position = 10)
     private Long likeCount;
+
+    @ApiModelProperty(value = "사용자 좋아요 여부", example = "false", position = 11)
     private Boolean isLiked;
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CursorPageResponse.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/dto/CursorPageResponse.java
@@ -1,0 +1,31 @@
+package team2.pjt12.matchumoney.domain.cardsearch.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "CursorPageResponse", description = "커서 기반 페이지네이션 공통 응답 래퍼")
+public class CursorPageResponse<T> {
+    @ApiModelProperty(value = "조회된 아이템 목록", position = 1
+    )
+    private List<T> items;
+
+    @ApiModelProperty(value = "다음 페이지 존재 여부", example = "true", position = 2)
+    private boolean hasNext;
+
+    @ApiModelProperty(
+            value = "다음 페이지 요청 시 사용할 커서(마지막 아이템 id), 없으면 null",
+            example = "42",
+            position = 3
+    )
+    private String nextCursor;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/mapper/CardSearchMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/mapper/CardSearchMapper.java
@@ -2,6 +2,7 @@ package team2.pjt12.matchumoney.domain.cardsearch.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CardListItemDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchRequestDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchResponseDTO;
 
@@ -11,6 +12,14 @@ import java.util.List;
 public interface CardSearchMapper {
 
     List<CardSearchResponseDTO> selectCardsByFilter(@Param("request") CardSearchRequestDTO request, @Param("userId") Long userId);
+
+    // 커서 기반 무한스크롤 (size+1 조회)
+    List<CardListItemDTO> selectCardsByCursor(
+            @Param("userId") Long userId,
+            @Param("request") CardSearchRequestDTO request,
+            @Param("cursorId") Long cursorId, // 마지막으로 본 id (null이면 첫 페이지)
+            @Param("limit") int limit // size+1로 호출
+    );
 }
 
 

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/service/CardSearchService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/service/CardSearchService.java
@@ -1,10 +1,13 @@
 package team2.pjt12.matchumoney.domain.cardsearch.service;
 
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CardListItemDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchRequestDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchResponseDTO;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CursorPageResponse;
 
 import java.util.List;
 
 public interface CardSearchService {
     List<CardSearchResponseDTO> searchCards(CardSearchRequestDTO request);
+    CursorPageResponse<CardListItemDTO> searchInfinite(Long userId, CardSearchRequestDTO req, String cursor, int size);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/service/CardSearchServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardsearch/service/CardSearchServiceImpl.java
@@ -3,8 +3,10 @@ package team2.pjt12.matchumoney.domain.cardsearch.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team2.pjt12.matchumoney.domain.carddetail.dto.CardOptionDTO;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CardListItemDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchRequestDTO;
 import team2.pjt12.matchumoney.domain.cardsearch.dto.CardSearchResponseDTO;
+import team2.pjt12.matchumoney.domain.cardsearch.dto.CursorPageResponse;
 import team2.pjt12.matchumoney.domain.cardsearch.mapper.CardSearchMapper;
 import team2.pjt12.matchumoney.domain.personacard.mapper.PersonaCardMapper;
 
@@ -29,22 +31,22 @@ public class CardSearchServiceImpl implements CardSearchService {
         return cards;
     }
 
-//    private List<PersonaCardDTO> getRandomizedCards(Long personaId) {
-//        List<PersonaCardDTO> allCards = personaCardMapper.selectCardsByPersonaId(personaId);
-//        log.info("🎯 조회된 카드 수: {}", allCards.size());
-//        Collections.shuffle(allCards);
-//
-//        List<PersonaCardDTO> recommendedCards = allCards.stream()
-//                .limit(RECOMMENDATION_LIMIT)
-//                .toList();
-//
-//        log.info("🎯 실제 추천 카드 수: {}", recommendedCards.size());
-//
-//        for (PersonaCardDTO card : recommendedCards) {
-//            List<CardOptionDTO> options = personaCardMapper.selectCardOptionsByCardId(card.getCardId());
-//            card.setOptions(options);
-//        }
-//
-//        return recommendedCards;
-//    }
+    @Override
+    public CursorPageResponse<CardListItemDTO> searchInfinite(Long userId, CardSearchRequestDTO req, String cursor, int size) {
+        // 커서 파싱
+        Long cursorId = (cursor == null || cursor.isBlank()) ? null : Long.parseLong(cursor);
+
+        // size+1로 조회 후 hasNext 판정
+        List<CardListItemDTO> rows = cardSearchMapper.selectCardsByCursor(userId, req, cursorId, size + 1);
+
+        boolean hasNext = rows.size() > size;
+        if (hasNext) rows = rows.subList(0, size);
+
+        String nextCursor = null;
+        if (hasNext && !rows.isEmpty()) {
+            Long lastId = rows.get(rows.size() - 1).getId();
+            nextCursor = String.valueOf(lastId); // 다음 요청에 cursor로 그대로 사용
+        }
+        return new CursorPageResponse<>(rows, hasNext, nextCursor);
+    }
 }

--- a/src/main/resources/mapper/CardSearchMapper.xml
+++ b/src/main/resources/mapper/CardSearchMapper.xml
@@ -24,7 +24,7 @@
         AND uf.user_id = #{userId}
         ) AS isStarred,
 
-        /* 좋아요 여부: EXISTS로 통일, 실제 컬럼명에 맞춰 card_id2 사용 */
+        /* 좋아요 여부 */
         EXISTS (
         SELECT 1
         FROM user_likes ul
@@ -32,7 +32,7 @@
         AND ul.user_id = #{userId}
         ) AS isLiked,
 
-        /* 좋아요 수: 동일 컬럼 사용 */
+        /* 좋아요 수 */
         (
         SELECT COUNT(*)
         FROM user_likes
@@ -75,6 +75,7 @@
             </if>
         </where>
     </select>
+
     <!-- 좋아요 여부 조회 -->
     <select id="isLikedByUser" resultType="boolean">
         SELECT EXISTS(
@@ -83,9 +84,6 @@
               AND card_id2 = #{cardProductId}
         )
     </select>
-
-
-
 
     <!-- 좋아요 개수 조회 -->
     <select id="countLikesByProductId" resultType="int">
@@ -103,4 +101,60 @@
         WHERE user_id = #{userId} AND card_id2 = #{cardProductId}
     </delete>
 
+    <!-- 커서 기반 무한 스크롤: id DESC -->
+    <select id="selectCardsByCursor"
+            resultType="team2.pjt12.matchumoney.domain.cardsearch.dto.CardListItemDTO">
+        SELECT /* DISTINCT 생략: 조인 시 중복 방지 필요하면 DISTINCT 유지 */
+        cp.card_product_id AS id,
+        cp.name,
+        cp.issuer,
+        cp.pre_month_money AS preMonthMoney,
+        cp.annual_fee      AS annualFee,
+        cp.card_image_url  AS imageUrl
+        FROM card_product cp
+
+        <!-- 혜택 필터 있을 때만 조인 -->
+        <if test="request.selectedBenefits != null and request.selectedBenefits.size() > 0">
+            LEFT JOIN card_search_benefit csb
+            ON cp.card_product_id = csb.card_id2
+        </if>
+
+        <where>
+            cp.is_available = 1
+
+            <!-- 카드 타입 필터 -->
+            <choose>
+                <when test="request.creditCard == true and request.debitCard == true">
+                    AND (cp.type = '신용' OR cp.type = '체크')
+                </when>
+                <when test="request.creditCard == true and request.debitCard == false">
+                    AND cp.type = '신용'
+                </when>
+                <when test="request.creditCard == false and request.debitCard == true">
+                    AND cp.type = '체크'
+                </when>
+                <otherwise>
+                    AND 1=1
+                </otherwise>
+            </choose>
+
+            <!-- 혜택 필터 (benefit_text의 첫 단어 매칭) -->
+            <if test="request.selectedBenefits != null and request.selectedBenefits.size() > 0">
+                AND (
+                <foreach item="benefit" collection="request.selectedBenefits" separator=" OR ">
+                    (csb.benefit_text IS NOT NULL
+                    AND SUBSTRING_INDEX(csb.benefit_text, ' ', 1) = #{benefit})
+                </foreach>
+                )
+            </if>
+
+            <!-- 커서 조건: id DESC에서 다음 페이지는 더 작은 id -->
+            <if test="cursorId != null">
+                AND cp.card_product_id &lt; #{cursorId}
+            </if>
+        </where>
+
+        ORDER BY cp.card_product_id DESC
+        LIMIT #{limit}
+    </select>
 </mapper>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 카드 검색 무한스크롤 API 구현

---

## 📎 관련 이슈
- Closes #105 

---

## 🛠 작업 내용
- 프론트에 구현되어 있던 무한스크롤 백엔드 처리로 전환
- Swagger 문서화


