### PR TITLE
[feat] 교육페이지 - 웹툰 데이터 api 구현

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/education/controller/WebtoonController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/controller/WebtoonController.java
@@ -1,0 +1,53 @@
+package team2.pjt12.matchumoney.domain.education.controller;
+
+import team2.pjt12.matchumoney.domain.education.dto.WebtoonResponseDTO;
+import team2.pjt12.matchumoney.domain.education.service.WebtoonService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/webtoon")
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+@Slf4j
+public class WebtoonController {
+
+    private final WebtoonService webtoonService;
+
+    /**
+     * 전체 웹툰 목록 조회
+     * GET /api/webtoon
+     */
+    @GetMapping
+    public ResponseEntity<List<WebtoonResponseDTO>> getAllWebtoons() {
+        try {
+            log.info("웹툰 목록 조회 요청");
+            List<WebtoonResponseDTO> webtoons = webtoonService.getAllWebtoons();
+            log.info("웹툰 목록 조회 성공. 조회된 웹툰 수: {}", webtoons.size());
+            return ResponseEntity.ok(webtoons);
+        } catch (Exception e) {
+            log.error("웹툰 목록 조회 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 전체 웹툰의 상위 4개 조회
+     * GET /api/webtoon/top4
+     */
+    @GetMapping("/top4")
+    public ResponseEntity<List<WebtoonResponseDTO>> getTop4Webtoons() {
+        try {
+            log.info("웹툰 목록 조회 ");
+            List<WebtoonResponseDTO> webtoons = webtoonService.getTop4Webtoons();
+            return ResponseEntity.ok(webtoons);
+        } catch (Exception e) {
+            log.error("웹툰 목록 조회 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/education/domain/WebtoonVO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/domain/WebtoonVO.java
@@ -1,0 +1,17 @@
+package team2.pjt12.matchumoney.domain.education.domain;
+
+import lombok.Data;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebtoonVO {
+    private Long id;
+    private String title;
+    private String fileDownUrl;
+    private Integer typeCode;
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/education/dto/WebtoonResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/dto/WebtoonResponseDTO.java
@@ -1,0 +1,46 @@
+package team2.pjt12.matchumoney.domain.education.dto;
+
+import team2.pjt12.matchumoney.domain.education.domain.WebtoonVO;
+import lombok.Data;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebtoonResponseDTO {
+
+    private Long id;
+    private String title;
+    private String fileDownUrl;
+    private String secondImageUrl;
+    private Integer typeCode;
+
+    /**
+     * WebtoonVO를 WebtoonResponseDTO로 변환하는 정적 팩토리 메서드
+     */
+    public static WebtoonResponseDTO from(WebtoonVO webtoon) {
+        return WebtoonResponseDTO.builder()
+                .id(webtoon.getId())
+                .title(webtoon.getTitle())
+                .fileDownUrl(webtoon.getFileDownUrl())
+                .secondImageUrl(generateSecondImageUrl(webtoon.getFileDownUrl()))
+                .typeCode(webtoon.getTypeCode())
+                .build();
+    }
+
+    /**
+     * 첫 번째 이미지 URL에서 두 번째 이미지 URL 생성
+     * &fileSn=1 을 &fileSn=2 로 변경
+     */
+    private static String generateSecondImageUrl(String firstUrl) {
+        if (firstUrl != null && firstUrl.contains("&fileSn=1")) {
+            return firstUrl.replace("&fileSn=1", "&fileSn=2");
+        }
+        return firstUrl;
+    }
+
+
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/education/mapper/WebtoonMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/mapper/WebtoonMapper.java
@@ -1,0 +1,23 @@
+package team2.pjt12.matchumoney.domain.education.mapper;
+
+import team2.pjt12.matchumoney.domain.education.domain.WebtoonVO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+@Mapper
+public interface WebtoonMapper {
+
+    /**
+     * 전체 웹툰 목록 조회
+     * @return 전체 웹툰 목록 추출
+     */
+    List<WebtoonVO> findWebtoonMain();
+
+    /**
+     * 전체 웹툰 목록 조회
+     * @return 전체 웹툰 목록 중 상위 4개 추출
+     */
+    List<WebtoonVO> findWebtoonMainTop4();
+
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/education/service/WebtoonService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/service/WebtoonService.java
@@ -1,0 +1,19 @@
+package team2.pjt12.matchumoney.domain.education.service;
+
+import team2.pjt12.matchumoney.domain.education.dto.WebtoonResponseDTO;
+import java.util.List;
+
+public interface WebtoonService {
+
+    /**
+     * 전체 웹툰 목록 조회
+     * @return 웹툰 응답 DTO 목록
+     */
+    List<WebtoonResponseDTO> getAllWebtoons();
+
+
+    List<WebtoonResponseDTO> getTop4Webtoons();
+
+
+
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/education/service/WebtoonServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/education/service/WebtoonServiceImpl.java
@@ -1,0 +1,68 @@
+package team2.pjt12.matchumoney.domain.education.service;
+
+import team2.pjt12.matchumoney.domain.education.domain.WebtoonVO;
+import team2.pjt12.matchumoney.domain.education.dto.WebtoonResponseDTO;
+import team2.pjt12.matchumoney.domain.education.mapper.WebtoonMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class WebtoonServiceImpl implements WebtoonService {
+
+    private final WebtoonMapper webtoonMapper;
+
+    /**
+     * 전체 웹툰 목록 조회
+     * @return 웹툰 응답 DTO 목록
+     */
+    @Override
+    public List<WebtoonResponseDTO> getAllWebtoons() {
+        log.info("전체 웹툰 목록 조회 시작");
+
+        try {
+            // 웹툰 메인 이미지 목록 조회 (fileSn=1)
+            List<WebtoonVO> webtoons = webtoonMapper.findWebtoonMain();
+
+            // WebtoonVO를 WebtoonResponseDTO로 변환
+            List<WebtoonResponseDTO> result = webtoons.stream()
+                    .map(WebtoonResponseDTO::from)
+                    .collect(Collectors.toList());
+
+            log.info("전체 웹툰 목록 조회 완료. 조회된 웹툰 수: {}", result.size());
+            return result;
+
+        } catch (Exception e) {
+            log.error("웹툰 목록 조회 중 오류 발생", e);
+            throw new RuntimeException("웹툰 목록 조회에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public List<WebtoonResponseDTO> getTop4Webtoons() {
+        log.info("웹툰 top4 리스트 조회 시작");
+
+        try {
+            // 웹툰 메인 이미지 목록 조회 (fileSn=1)
+            List<WebtoonVO> webtoons = webtoonMapper.findWebtoonMainTop4();
+
+            // WebtoonVO를 WebtoonResponseDTO로 변환
+            List<WebtoonResponseDTO> result = webtoons.stream()
+                    .map(WebtoonResponseDTO::from)
+                    .collect(Collectors.toList());
+
+            log.info("웹툰 top4 리스트 조회 완료");
+            return result;
+
+        } catch (Exception e) {
+            log.error("웹툰 목록 top4 조회 중 오류 발생", e);
+            throw new RuntimeException("웹툰 목록 top4 조회에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/global/config/SecurityConfig.java
+++ b/src/main/java/team2/pjt12/matchumoney/global/config/SecurityConfig.java
@@ -70,7 +70,9 @@ public class SecurityConfig {
                                         "/api/saving-products/**",
                                         "/api/card-products/**",
                                         "/api/like/**",
-                                        "/api/favorite/**"
+                                        "/api/favorite/**",
+                                        "/api/webtoon",
+                                        "api/webtoon/**"
                                 ).permitAll()  // 허용 URL 설정
                                 .requestMatchers("/user/update").authenticated()
                                 .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -37,7 +37,6 @@
             last_modified_time,
             is_social_login,
             persona_id,
-            favorite_id,
             exp,
             gender,
             birth_date
@@ -60,7 +59,6 @@
             last_modified_time,
             is_social_login,
             persona_id,
-            favorite_id,
             exp,
             gender,
             birth_date
@@ -88,7 +86,6 @@
             last_modified_time,
             is_social_login,
             persona_id,
-            favorite_id,
             exp,
             gender,
             birth_date

--- a/src/main/resources/mapper/WebtoonMapper.xml
+++ b/src/main/resources/mapper/WebtoonMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="team2.pjt12.matchumoney.domain.education.mapper.WebtoonMapper">
+    <resultMap id="InformationBoardResultMap" type="team2.pjt12.matchumoney.domain.education.domain.WebtoonVO">
+        <id property="id" column="id" />
+        <result property="title" column="title" />
+        <result property="fileDownUrl" column="fileDownUrl" />
+        <result property="typeCode" column="typeCode" />
+    </resultMap>
+
+    <!-- 웹툰 메인 이미지 조회 (typeCode=3) -->
+    <select id="findWebtoonMain" resultMap="InformationBoardResultMap">
+        SELECT
+            id,
+            title,
+            fileDownUrl,
+            typeCode
+        FROM information_board
+        WHERE typeCode = 3
+          AND fileDownUrl LIKE '%fileSn=1%'
+        ORDER BY id DESC
+    </select>
+
+    <!-- 웹툰 상위 4개만 추출  -->
+    <select id="findWebtoonMainTop4" resultMap="InformationBoardResultMap">
+        SELECT
+            id,
+            title,
+            fileDownUrl,
+            typeCode
+        FROM information_board
+        WHERE typeCode = 3
+          AND fileDownUrl LIKE '%fileSn=1%'
+        ORDER BY id DESC
+        LIMIT 4
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🔥 PR 제목
[feat] 교육페이지 - 웹툰 데이터 가져오기

---

## 📎 관련 이슈
- Closes #114 

---

## 🛠 작업 내용
- 교육 페이지 금융 웹툰 데이터 api 구현
- 
<img width="2246" height="944" alt="image" src="https://github.com/user-attachments/assets/bf6da79f-05ba-4dee-8789-f85204baf80d" />



