### PR TITLE
[Feat] 마이페이지 상위 퍼센트 API 구현

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/user/controller/UserController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/controller/UserController.java
@@ -8,10 +8,13 @@ import team2.pjt12.matchumoney.domain.user.dto.req.UpdateUserInfoRequestDTO;
 import team2.pjt12.matchumoney.domain.user.dto.res.MyPageResponseDTO;
 import team2.pjt12.matchumoney.domain.user.dto.res.UserResponseDTO;
 import team2.pjt12.matchumoney.domain.user.dto.res.UserUpdateResponseDTO;
+import team2.pjt12.matchumoney.domain.user.service.UserPercentileService;
 import team2.pjt12.matchumoney.domain.user.service.UserService;
 import team2.pjt12.matchumoney.global.success.SuccessResponse;
 
 import javax.validation.Valid;
+
+import static team2.pjt12.matchumoney.global.util.SecurityUtils.getCurrentUser;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ import javax.validation.Valid;
 public class UserController {
 
     private final UserService userService;
+    private final UserPercentileService userPercentileService;
 
     @PatchMapping("/update")
     public SuccessResponse<UserUpdateResponseDTO> updateUserInfo(@RequestBody @Valid UpdateUserInfoRequestDTO reqDto) {
@@ -52,4 +56,10 @@ public class UserController {
         return new SuccessResponse<>("페르소나 저장 성공");
     }
 
+    @GetMapping("/mypage/top-percent")
+    public SuccessResponse<Integer> getMyTopPercent() {
+        long userId = getCurrentUser().getUserId();
+        int top = userPercentileService.calcTopPercent(userId);
+        return new SuccessResponse<>(top, "전체 유저 누적 EXP 기준 상위 퍼센트");
+    }
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/user/dto/res/TopPercentResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/dto/res/TopPercentResponseDTO.java
@@ -1,0 +1,16 @@
+package team2.pjt12.matchumoney.domain.user.dto.res;
+
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@ApiModel(value = "TopPercentResponse", description = "전체 유저 누적 EXP 기준 상위 퍼센트")
+public class TopPercentResponseDTO {
+
+    @ApiModelProperty(value = "상위 퍼센트(정수 %)", example = "12", allowableValues = "range[1,100]")
+    private final int topPercent; // 예: 12 -> 상위 12%
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/user/mapper/UserMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/mapper/UserMapper.java
@@ -17,6 +17,7 @@ import team2.pjt12.matchumoney.domain.user.dto.res.MyPageResponseDTO;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Mapper
@@ -79,4 +80,9 @@ public interface UserMapper {
     
     // 경험치(EXP) 업데이트
     void updateUserExp(@Param("userId") Long userId, @Param("expAmount") int expAmount);
+
+    // 상위 퍼센트용
+    Long percentileFindExpByUserId(@Param("userId") Long userId);
+    Long percentileCountAllUsers();
+    Map<String, Object> percentileCountLowerAndEqualByExp(@Param("exp") long exp);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/user/service/UserPercentileService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/service/UserPercentileService.java
@@ -1,0 +1,5 @@
+package team2.pjt12.matchumoney.domain.user.service;
+
+public interface UserPercentileService {
+    int calcTopPercent(long userId);
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/user/service/UserPercentileServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/user/service/UserPercentileServiceImpl.java
@@ -1,0 +1,42 @@
+package team2.pjt12.matchumoney.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team2.pjt12.matchumoney.domain.user.mapper.UserMapper;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class UserPercentileServiceImpl implements UserPercentileService {
+    private final UserMapper userMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public int calcTopPercent(long userId) {
+        long myExp = nz(userMapper.percentileFindExpByUserId(userId));
+        long total = nz(userMapper.percentileCountAllUsers());
+        if (total <= 0) return 0;
+
+        Map<String, Object> m = userMapper.percentileCountLowerAndEqualByExp(myExp);
+        long lower = toLong(m.get("lowerCnt")); // 내 exp보다 작은 사람 수
+        long equal = toLong(m.get("equalCnt")); // 내 exp와 같은 사람 수(본인 포함)
+
+        // 1등은 항상 1%
+        boolean isTopGroup = (lower + equal) >= total;
+        if (isTopGroup) return 1;
+
+        // mid-rank 하위 백분위
+        double percentile = ((lower + 0.5d * equal) / (double) total) * 100.0d;
+
+        // 상위 퍼센트로 전환 (100 - percentile)
+        int top = (int) Math.ceil(100.0d - percentile);
+
+        // 표시 보정 (1~100)
+        return Math.max(1, Math.min(100, top));
+    }
+
+    private long nz(Long v) { return v == null ? 0L : v; }
+    private long toLong(Object v) { return v == null ? 0L : ((Number) v).longValue(); }
+}

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -437,4 +437,20 @@
         SET exp = exp + #{expAmount}
         WHERE user_id = #{userId}
     </update>
+
+    <!-- 상위 퍼센트용 -->
+    <select id="percentileFindExpByUserId" parameterType="long" resultType="long">
+        SELECT COALESCE(exp, 0) FROM users WHERE user_id = #{userId}
+    </select>
+
+    <select id="percentileCountAllUsers" resultType="long">
+        SELECT COUNT(*) FROM users
+    </select>
+
+    <select id="percentileCountLowerAndEqualByExp" parameterType="long" resultType="map">
+        SELECT
+            SUM(CASE WHEN exp &lt; #{exp} THEN 1 ELSE 0 END) AS lowerCnt,
+            SUM(CASE WHEN exp = #{exp} THEN 1 ELSE 0 END) AS equalCnt
+        FROM users
+    </select>
 </mapper>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 마이페이지 상위 퍼센트 API 구현

---

## 📎 관련 이슈
- Closes #115 

---

## 🛠 작업 내용
- 사용자의 누적 경험치를 기준으로 전체 유저 대비 상위 퍼센트를 계산·반환하는 API 구현
- 상위 퍼센트 산정 방식

  > N = 전체 유저 수
  L = 내 exp보다 낮은 유저 수
  E = 내 exp와 같은 유저 수 (본인 포함)<br>
  하위비율 p = ((L + 0.5 * E) / N) * 100
  상위퍼센트 topPercent = ceil(100 - p)

    - 동점은 mid-rank로 처리, 최고 경험치를 가진 그룹(1등)은 예외적으로 항상 상위 1%가 되도록 보정
    - 응답은 1~100 정수로 반환

