### PR TITLE
[Feat] kb카드 리스트,거래내역 무한 스크롤

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/controller/CardRecommendationController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/controller/CardRecommendationController.java
@@ -268,13 +268,18 @@ public class CardRecommendationController {
             @ApiResponse(code = 200, message = "KB국민카드 추천 성공"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
-    public ResponseEntity<KbCardRecommendationResponseDTO> getKbCardRecommendations() {
+    public ResponseEntity<KbCardRecommendationResponseDTO> getKbCardRecommendations(
+            @ApiParam(value = "페이지 번호 (0부터 시작, 기본값: 0)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @ApiParam(value = "페이지 크기 (기본값: 6)", example = "6")
+            @RequestParam(defaultValue = "6") int size) {
         try {
-            log.info("KB국민카드 추천 요청");
+            log.info("KB국민카드 추천 요청 - page: {}, size: {}", page, size);
             
-            KbCardRecommendationResponseDTO response = cardRecommendationService.recommendKbCards();
+            KbCardRecommendationResponseDTO response = cardRecommendationService.recommendKbCardsWithPaging(page, size);
             
-            log.info("KB국민카드 추천 완료: {} 개", response.getTotalCount());
+            log.info("KB국민카드 추천 완료 - page: {}, count: {}, hasNext: {}", 
+                page, response.getKbCards().size(), response.isHasNext());
             return ResponseEntity.ok(response);
             
         } catch (Exception e) {

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/dto/KbCardRecommendationResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/dto/KbCardRecommendationResponseDTO.java
@@ -1,5 +1,6 @@
 package team2.pjt12.matchumoney.domain.cardrecommendation.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,9 @@ public class KbCardRecommendationResponseDTO {
     private List<KbCardProductDTO> kbCards;
     private int totalCount;
     private String message;
+    private boolean hasNext;
+    private int currentPage;
+    private int pageSize;
 
     @Getter
     @Setter
@@ -36,5 +40,14 @@ public class KbCardRecommendationResponseDTO {
         private String corpPrContainer;
         private String corpTips;
         private String issuer;
+        
+        @JsonProperty("is_liked")
+        private Boolean liked;
+        
+        @JsonProperty("like_count")
+        private Integer likeCount;
+        
+        @JsonProperty("is_favorited")
+        private Boolean favorited;
     }
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/mapper/CardRecommendationMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/mapper/CardRecommendationMapper.java
@@ -152,4 +152,24 @@ public interface CardRecommendationMapper {
      * @return 발급 가능한 카드 목록
      */
     List<CardProductVO> selectAvailableCardsByIssuer(@Param("issuer") String issuer);
+    
+    /**
+     * 발급사별로 발급 가능한 카드 목록을 페이징하여 조회합니다.
+     * @param issuer 발급사명 (예: KB국민카드)
+     * @param offset 시작 위치
+     * @param limit 조회할 개수
+     * @return 발급 가능한 카드 목록 (페이징)
+     */
+    List<CardProductVO> selectAvailableCardsByIssuerWithPaging(
+        @Param("issuer") String issuer,
+        @Param("offset") int offset,
+        @Param("limit") int limit
+    );
+    
+    /**
+     * 발급사별 총 카드 개수를 조회합니다.
+     * @param issuer 발급사명 (예: KB국민카드)
+     * @return 총 카드 개수
+     */
+    int countAvailableCardsByIssuer(@Param("issuer") String issuer);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationService.java
@@ -54,4 +54,12 @@ public interface CardRecommendationService {
      * @return KB국민카드 추천 목록
      */
     KbCardRecommendationResponseDTO recommendKbCards();
+    
+    /**
+     * KB국민카드에서 발급 가능한 카드 목록을 페이징하여 추천합니다.
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @return KB국민카드 추천 목록 (페이징)
+     */
+    KbCardRecommendationResponseDTO recommendKbCardsWithPaging(int page, int size);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/cardrecommendation/service/CardRecommendationServiceImpl.java
@@ -12,6 +12,7 @@ import team2.pjt12.matchumoney.domain.mydata.service.MerchantCategoryService;
 import team2.pjt12.matchumoney.domain.cardrecommendation.vo.*;
 import team2.pjt12.matchumoney.domain.carddetail.mapper.CardDetailMapper;
 import team2.pjt12.matchumoney.domain.user.mapper.UserMapper;
+import team2.pjt12.matchumoney.global.util.SecurityUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -543,12 +544,25 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
     public KbCardRecommendationResponseDTO recommendKbCards() {
         log.info("KB국민카드 추천 카드 목록 조회 시작");
         
+        Long userId = null;
+        try {
+            userId = SecurityUtils.getCurrentUserId();
+        } catch (Exception e) {
+            log.debug("사용자 ID 조회 실패 (비로그인 상태일 수 있음): {}", e.getMessage());
+        }
+        
         try {
             List<CardProductVO> kbCards = cardRecommendationMapper.selectAvailableCardsByIssuer("KB국민카드");
             
             List<KbCardRecommendationResponseDTO.KbCardProductDTO> kbCardDTOs = kbCards.stream()
                 .map(this::convertToKbCardDTO)
                 .collect(Collectors.toList());
+                
+            // 로그인한 사용자인 경우 좋아요와 즐겨찾기 상태 설정
+            if (userId != null) {
+                final Long finalUserId = userId;
+                kbCardDTOs.forEach(cardDto -> setKbCardLikeAndFavoriteStatus(finalUserId, cardDto));
+            }
             
             String message = String.format("KB국민카드에서 발급 가능한 카드 %d개를 조회했습니다.", kbCardDTOs.size());
             
@@ -566,6 +580,67 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
                 .kbCards(Collections.emptyList())
                 .totalCount(0)
                 .message("KB국민카드 추천 조회 중 오류가 발생했습니다.")
+                .build();
+        }
+    }
+    
+    @Override
+    public KbCardRecommendationResponseDTO recommendKbCardsWithPaging(int page, int size) {
+        log.info("KB국민카드 페이징 추천 카드 목록 조회 시작 - page: {}, size: {}", page, size);
+        
+        Long userId = null;
+        try {
+            userId = SecurityUtils.getCurrentUserId();
+        } catch (Exception e) {
+            log.debug("사용자 ID 조회 실패 (비로그인 상태일 수 있음): {}", e.getMessage());
+        }
+        
+        try {
+            // 총 개수 조회
+            int totalCount = cardRecommendationMapper.countAvailableCardsByIssuer("KB국민카드");
+            
+            // 페이징 계산
+            int offset = page * size;
+            boolean hasNext = (offset + size) < totalCount;
+            
+            // 페이징된 카드 목록 조회
+            List<CardProductVO> kbCards = cardRecommendationMapper.selectAvailableCardsByIssuerWithPaging(
+                "KB국민카드", offset, size);
+            
+            List<KbCardRecommendationResponseDTO.KbCardProductDTO> kbCardDTOs = kbCards.stream()
+                .map(this::convertToKbCardDTO)
+                .collect(Collectors.toList());
+                
+            // 로그인한 사용자인 경우 좋아요와 즐겨찾기 상태 설정
+            if (userId != null) {
+                final Long finalUserId = userId;
+                kbCardDTOs.forEach(cardDto -> setKbCardLikeAndFavoriteStatus(finalUserId, cardDto));
+            }
+            
+            String message = String.format("KB국민카드 %d페이지: %d개 카드 (전체 %d개)", 
+                page + 1, kbCardDTOs.size(), totalCount);
+            
+            log.info("KB국민카드 페이징 추천 완료 - page: {}, size: {}, hasNext: {}", 
+                page, kbCardDTOs.size(), hasNext);
+
+            return KbCardRecommendationResponseDTO.builder()
+                .kbCards(kbCardDTOs)
+                .totalCount(totalCount)
+                .message(message)
+                .hasNext(hasNext)
+                .currentPage(page)
+                .pageSize(size)
+                .build();
+                
+        } catch (Exception e) {
+            log.error("KB국민카드 페이징 추천 중 오류 발생", e);
+            return KbCardRecommendationResponseDTO.builder()
+                .kbCards(Collections.emptyList())
+                .totalCount(0)
+                .message("KB국민카드 추천 조회 중 오류가 발생했습니다.")
+                .hasNext(false)
+                .currentPage(page)
+                .pageSize(size)
                 .build();
         }
     }
@@ -588,6 +663,36 @@ public class CardRecommendationServiceImpl implements CardRecommendationService 
             .corpTips(card.getCorpTips())
             .issuer(card.getIssuer())
             .build();
+    }
+    
+    /**
+     * KB 카드 DTO에 좋아요와 즐겨찾기 상태를 설정합니다.
+     */
+    private void setKbCardLikeAndFavoriteStatus(Long userId, KbCardRecommendationResponseDTO.KbCardProductDTO cardDto) {
+        if (userId != null && cardDto.getCardProductId() != null) {
+            try {
+                // 좋아요 상태 조회
+                boolean isLiked = cardDetailMapper.isLikedByUser(userId, cardDto.getCardProductId());
+                int likeCount = cardDetailMapper.countLikesByProductId(cardDto.getCardProductId());
+                cardDto.setLiked(isLiked);
+                cardDto.setLikeCount(likeCount);
+                
+                // 즐겨찾기 상태 조회
+                boolean isFavorited = userMapper.isCardFavoriteExists(userId, Long.valueOf(cardDto.getCardProductId()));
+                cardDto.setFavorited(isFavorited);
+            } catch (Exception e) {
+                log.warn("KB 카드 {} 좋아요/즐겨찾기 상태 조회 실패: {}", cardDto.getCardProductId(), e.getMessage());
+                // 기본값 설정
+                cardDto.setLiked(false);
+                cardDto.setLikeCount(0);
+                cardDto.setFavorited(false);
+            }
+        } else {
+            // 기본값 설정
+            cardDto.setLiked(false);
+            cardDto.setLikeCount(0);
+            cardDto.setFavorited(false);
+        }
     }
     
     /**

--- a/src/main/resources/mapper/CardRecommendationMapper.xml
+++ b/src/main/resources/mapper/CardRecommendationMapper.xml
@@ -310,5 +310,42 @@
         AND is_available = 1
         ORDER BY pre_month_money ASC, name ASC
     </select>
+    
+    <!-- 발급사별로 발급 가능한 카드 목록을 페이징하여 조회 -->
+    <select id="selectAvailableCardsByIssuerWithPaging" resultType="team2.pjt12.matchumoney.domain.cardrecommendation.vo.CardProductVO">
+        SELECT 
+            card_product_id as cardProductId,
+            name,
+            type,
+            is_available as isAvailable,
+            issuer_id as issuerId,
+            annual_fee as annualFee,
+            pre_month_money as preMonthMoney,
+            online_only as onlineOnly,
+            card_image_url as cardImageUrl,
+            request_pc_url as requestPcUrl,
+            request_mobile_url as requestMobileUrl,
+            annual_fee_detail as annualFeeDetail,
+            corp_pr_container as corpPrContainer,
+            corp_pr_detail as corpPrDetail,
+            corp_tips as corpTips,
+            created_time as createdTime,
+            last_modified_time as lastModifiedTime,
+            persona_id as personaId,
+            issuer
+        FROM card_product
+        WHERE issuer = #{issuer}
+        AND is_available = 1
+        ORDER BY pre_month_money ASC, name ASC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+    
+    <!-- 발급사별 총 카드 개수 조회 -->
+    <select id="countAvailableCardsByIssuer" resultType="int">
+        SELECT COUNT(*)
+        FROM card_product
+        WHERE issuer = #{issuer}
+        AND is_available = 1
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] kb카드 리스트,거래내역 무한 스크롤

---

## 📎 관련 이슈
- Closes #122

---

## 🛠 작업 내용
- kb 카드에 대한 리스트를 무한 스크롤 처리
- 카드 거래내역에 대한 리스트를 무한 스크롤 처리


