### PR TITLE
[Feat] 퀴즈 이력 조회

### DIFF
--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/controller/QuizController.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/controller/QuizController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizHistoryResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
@@ -14,6 +15,7 @@ import team2.pjt12.matchumoney.global.security.UserDetailsImpl;
 import team2.pjt12.matchumoney.global.success.SuccessResponse;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,12 +29,12 @@ public class QuizController {
     @GetMapping("/today")
     @ApiOperation(
             value = "오늘의 퀴즈 문제 조회",
-            notes = "사용자별로 오늘 풀어야 할 금융 퀴즈 문제를 1개 제공합니다. 이미 오늘 문제를 모두 푼 경우 400 오류가 발생할 수 있습니다."
+            notes = "사용자별로 오늘 풀어야 할 금융 퀴즈 문제를 제공합니다. 하루에 최대 2개까지 풀 수 있으며, 이미 오늘 문제를 모두 푼 경우 400 오류가 발생할 수 있습니다."
     )
     @ApiResponses({
             @ApiResponse(code = 200, message = "퀴즈 문제 조회 성공"),
             @ApiResponse(code = 401, message = "인증 실패"),
-            @ApiResponse(code = 400, message = "오늘 풀 수 있는 문제가 없음")
+            @ApiResponse(code = 400, message = "오늘 풀 수 있는 문제가 없음 (최대 2개 제한)")
     })
     public SuccessResponse<QuizProblemResponseDTO> getTodayQuiz(
             @ApiParam(hidden = true) Authentication authentication) {
@@ -79,10 +81,10 @@ public class QuizController {
     @GetMapping("/today/completed")
     @ApiOperation(
             value = "오늘의 퀴즈 완료 여부 조회",
-            notes = "오늘 퀴즈를 모두 풀었는지 여부를 반환합니다. true면 완료, false면 아직 미완료입니다."
+            notes = "오늘 퀴즈를 모두 풀었는지 여부를 반환합니다. 하루에 2개 문제를 모두 풀었으면 true, 아직 풀 수 있는 문제가 있으면 false를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(code = 200, message = "오늘의 퀴즈 완료 여부 반환"),
+            @ApiResponse(code = 200, message = "오늘의 퀴즈 완료 여부 반환 (2개 모두 완료 시 true)"),
             @ApiResponse(code = 401, message = "인증 실패")
     })
     public SuccessResponse<Boolean> checkTodayQuizCompleted(
@@ -90,6 +92,22 @@ public class QuizController {
         Long userId = getUserId(authentication);
         boolean completed = quizService.hasCompletedTodayQuiz(userId);
         return new SuccessResponse<>(completed);
+    }
+
+    @GetMapping("/history")
+    @ApiOperation(
+            value = "퀴즈 이력 조회",
+            notes = "사용자가 최근 풀었던 퀴즈 이력을 최대 5개까지 조회합니다. 각 이력에는 문제, 정답, 사용자 답안, 해설이 포함됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "퀴즈 이력 조회 성공"),
+            @ApiResponse(code = 401, message = "인증 실패")
+    })
+    public SuccessResponse<List<QuizHistoryResponseDTO>> getQuizHistory(
+            @ApiParam(hidden = true) Authentication authentication) {
+        Long userId = getUserId(authentication);
+        List<QuizHistoryResponseDTO> history = quizService.getQuizHistory(userId);
+        return new SuccessResponse<>(history);
     }
 
     private Long getUserId(Authentication authentication) {

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizHistoryResponseDTO.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/dto/res/QuizHistoryResponseDTO.java
@@ -1,0 +1,33 @@
+package team2.pjt12.matchumoney.domain.quiz.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class QuizHistoryResponseDTO {
+    
+    private Long logId;
+    private String quizText;
+    private Boolean userAnswer;
+    private Boolean correctAnswer;
+    private Boolean isCorrect;
+    private String explanation;
+    private LocalDateTime solvedTime;
+    
+    public static QuizHistoryResponseDTO from(QuizLogVO quizLog, QuizProblemVO quizProblem) {
+        return QuizHistoryResponseDTO.builder()
+                .logId(quizLog.getLogId())
+                .quizText(quizProblem.getQuizText())
+                .userAnswer(quizLog.getUserAnswer())
+                .correctAnswer(quizProblem.getQuizAnswer())
+                .isCorrect(quizLog.getIsCorrect())
+                .explanation(quizProblem.getExplanation())
+                .solvedTime(quizLog.getSolvedTime())
+                .build();
+    }
+}

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizLogMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizLogMapper.java
@@ -22,6 +22,8 @@ public interface QuizLogMapper {
     
     boolean existsByUserIdAndDate(@Param("userId") Long userId, @Param("solvedDate") LocalDate solvedDate);
     
+    int getTodayQuizCountByUserId(@Param("userId") Long userId, @Param("solvedDate") LocalDate solvedDate);
+    
     boolean existsByUserIdAndProblemId(@Param("userId") Long userId, @Param("problemId") Long problemId);
     
     int getCorrectCountByUserId(@Param("userId") Long userId);
@@ -31,6 +33,8 @@ public interface QuizLogMapper {
     int getCurrentStreakByUserId(@Param("userId") Long userId);
     
     List<QuizLogVO> findRecentLogsByUserId(@Param("userId") Long userId, @Param("limit") int limit);
+    
+    List<QuizLogVO> findRecentHistoryByUserId(@Param("userId") Long userId, @Param("limit") int limit);
     
     void deleteById(@Param("logId") Long logId);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizProblemMapper.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/mapper/QuizProblemMapper.java
@@ -28,4 +28,6 @@ public interface QuizProblemMapper {
     int getTotalCount();
     
     int getUnsolvedCountByUserId(@Param("userId") Long userId);
+    
+    List<QuizProblemVO> findByLogIds(@Param("logIds") List<Long> logIds);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizService.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizService.java
@@ -1,9 +1,12 @@
 package team2.pjt12.matchumoney.domain.quiz.service;
 
 import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizHistoryResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
+
+import java.util.List;
 
 public interface QuizService {
 
@@ -14,4 +17,6 @@ public interface QuizService {
     QuizStatsResponseDTO getUserQuizStats(Long userId);
     
     boolean hasCompletedTodayQuiz(Long userId);
+    
+    List<QuizHistoryResponseDTO> getQuizHistory(Long userId);
 }

--- a/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO;
 import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
 import team2.pjt12.matchumoney.domain.quiz.dto.req.QuizAnswerRequestDTO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizHistoryResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizProblemResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizResultResponseDTO;
 import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizStatsResponseDTO;
@@ -14,6 +15,9 @@ import team2.pjt12.matchumoney.domain.quiz.mapper.QuizProblemMapper;
 import team2.pjt12.matchumoney.domain.user.mapper.UserMapper;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,12 @@ public class QuizServiceImpl implements QuizService {
 
     @Override
     public QuizProblemResponseDTO getTodayQuiz(Long userId) {
+        // 오늘 풀은 퀴즈 개수 확인 (하루 최대 2개 제한)
+        int todayQuizCount = quizLogMapper.getTodayQuizCountByUserId(userId, LocalDate.now());
+        if (todayQuizCount >= 2) {
+            throw new RuntimeException("오늘 퀴즈를 모두 완료했습니다! 하루에 최대 2개까지 풀 수 있습니다.");
+        }
+
         int unsolvedCount = quizProblemMapper.getUnsolvedCountByUserId(userId);
 
         if (unsolvedCount == 0) {
@@ -97,6 +107,33 @@ public class QuizServiceImpl implements QuizService {
 
     @Override
     public boolean hasCompletedTodayQuiz(Long userId) {
-        return quizLogMapper.existsByUserIdAndDate(userId, LocalDate.now());
+        // 하루에 2개 문제를 모두 풀었는지 확인
+        int todayQuizCount = quizLogMapper.getTodayQuizCountByUserId(userId, LocalDate.now());
+        return todayQuizCount >= 2;
+    }
+
+    @Override
+    public List<QuizHistoryResponseDTO> getQuizHistory(Long userId) {
+        List<QuizLogVO> recentLogs = quizLogMapper.findRecentHistoryByUserId(userId, 5);
+        
+        if (recentLogs.isEmpty()) {
+            return List.of();
+        }
+        
+        List<Long> problemIds = recentLogs.stream()
+                .map(QuizLogVO::getProblemId)
+                .collect(Collectors.toList());
+        
+        List<QuizProblemVO> problems = quizProblemMapper.findByLogIds(problemIds);
+        
+        Map<Long, QuizProblemVO> problemMap = problems.stream()
+                .collect(Collectors.toMap(QuizProblemVO::getProblemId, problem -> problem));
+        
+        return recentLogs.stream()
+                .map(log -> {
+                    QuizProblemVO problem = problemMap.get(log.getProblemId());
+                    return QuizHistoryResponseDTO.from(log, problem);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/mapper/QuizLogMapper.xml
+++ b/src/main/resources/mapper/QuizLogMapper.xml
@@ -42,6 +42,13 @@
           AND solved_date = #{solvedDate}
     </select>
 
+    <select id="getTodayQuizCountByUserId" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_log
+        WHERE user_id = #{userId}
+          AND solved_date = #{solvedDate}
+    </select>
+
     <select id="existsByUserIdAndProblemId" resultType="boolean">
         SELECT COUNT(*) > 0
         FROM quiz_log
@@ -80,6 +87,14 @@
     </select>
 
     <select id="findRecentLogsByUserId" resultMap="QuizLogResultMap">
+        SELECT log_id, user_id, problem_id, user_answer, is_correct, solved_time, solved_date
+        FROM quiz_log
+        WHERE user_id = #{userId}
+        ORDER BY solved_time DESC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findRecentHistoryByUserId" resultMap="QuizLogResultMap">
         SELECT log_id, user_id, problem_id, user_answer, is_correct, solved_time, solved_date
         FROM quiz_log
         WHERE user_id = #{userId}

--- a/src/main/resources/mapper/QuizProblemMapper.xml
+++ b/src/main/resources/mapper/QuizProblemMapper.xml
@@ -90,4 +90,13 @@
         )
     </select>
 
+    <select id="findByLogIds" resultMap="QuizProblemResultMap">
+        SELECT problem_id, quiz_text, quiz_answer, explanation, created_time, last_modified_time
+        FROM quiz_problem
+        WHERE problem_id IN
+        <foreach item="id" collection="logIds" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+
 </mapper>

--- a/src/test/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceTest.java
+++ b/src/test/java/team2/pjt12/matchumoney/domain/quiz/service/QuizServiceTest.java
@@ -1,0 +1,104 @@
+package team2.pjt12.matchumoney.domain.quiz.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizLogVO;
+import team2.pjt12.matchumoney.domain.quiz.domain.QuizProblemVO;
+import team2.pjt12.matchumoney.domain.quiz.dto.res.QuizHistoryResponseDTO;
+import team2.pjt12.matchumoney.domain.quiz.mapper.QuizLogMapper;
+import team2.pjt12.matchumoney.domain.quiz.mapper.QuizProblemMapper;
+import team2.pjt12.matchumoney.domain.user.mapper.UserMapper;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuizServiceTest {
+
+    @Mock
+    private QuizProblemMapper quizProblemMapper;
+
+    @Mock
+    private QuizLogMapper quizLogMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private QuizServiceImpl quizService;
+
+    @Test
+    @DisplayName("퀴즈 이력 조회 - 정상적으로 최대 5개 조회")
+    void getQuizHistory_Success() {
+        // given
+        Long userId = 1L;
+        
+        List<QuizLogVO> mockLogs = Arrays.asList(
+                createMockQuizLog(1L, 1L, true, LocalDateTime.now().minusDays(1)),
+                createMockQuizLog(2L, 2L, false, LocalDateTime.now().minusDays(2)),
+                createMockQuizLog(3L, 3L, true, LocalDateTime.now().minusDays(3))
+        );
+        
+        List<QuizProblemVO> mockProblems = Arrays.asList(
+                createMockQuizProblem(1L, "문제1", true, "설명1"),
+                createMockQuizProblem(2L, "문제2", false, "설명2"),
+                createMockQuizProblem(3L, "문제3", true, "설명3")
+        );
+        
+        when(quizLogMapper.findRecentHistoryByUserId(userId, 5)).thenReturn(mockLogs);
+        when(quizProblemMapper.findByLogIds(any())).thenReturn(mockProblems);
+        
+        // when
+        List<QuizHistoryResponseDTO> result = quizService.getQuizHistory(userId);
+        
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getQuizText()).isEqualTo("문제1");
+        assertThat(result.get(0).getIsCorrect()).isTrue();
+        assertThat(result.get(1).getQuizText()).isEqualTo("문제2");
+        assertThat(result.get(1).getIsCorrect()).isFalse();
+    }
+
+    @Test
+    @DisplayName("퀴즈 이력 조회 - 이력이 없는 경우 빈 리스트 반환")
+    void getQuizHistory_EmptyHistory() {
+        // given
+        Long userId = 1L;
+        when(quizLogMapper.findRecentHistoryByUserId(userId, 5)).thenReturn(List.of());
+        
+        // when
+        List<QuizHistoryResponseDTO> result = quizService.getQuizHistory(userId);
+        
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private QuizLogVO createMockQuizLog(Long logId, Long problemId, Boolean isCorrect, LocalDateTime solvedTime) {
+        return QuizLogVO.builder()
+                .userId(1L)
+                .problemId(problemId)
+                .userAnswer(isCorrect)
+                .isCorrect(isCorrect)
+                .solvedDate(solvedTime.toLocalDate())
+                .build();
+    }
+
+    private QuizProblemVO createMockQuizProblem(Long problemId, String quizText, Boolean quizAnswer, String explanation) {
+        return QuizProblemVO.builder()
+                .problemId(problemId)
+                .quizText(quizText)
+                .quizAnswer(quizAnswer)
+                .explanation(explanation)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 PR 제목
- [Feat] 퀴즈 이력 조회

---

## 📎 관련 이슈
- Closes #126

---

## 🛠 작업 내용
- 퀴즈의 히스토리 로그를 5개를 조회 가능한 api 설계



